### PR TITLE
Initial Spec Doc Appendix Updates

### DIFF
--- a/oracle-spec/src/main/asciidoc/TagLibrary.adoc
+++ b/oracle-spec/src/main/asciidoc/TagLibrary.adoc
@@ -8236,21 +8236,15 @@ Removes white space from both ends of a
 string according to the semantics of method _trim()_ of the Java class
 _java.lang.String_ .
 
-
+[appendix]
 == Compatibility & Migration
-
-image:taglib-65.png[image]
 
 This appendix provides
 information on compatibility between different versions of JSTL, as well
 as on how to migrate your web application to take advantage of the new
 features of the latest JSTL release.
 
-
-
-image:taglib-66.png[image]
-
-JSTL 1.2 Backwards Compatibility
+=== JSTL 1.2 Backwards Compatibility
 
 JSTL 1.2 is backwards compatible with JSTL 1.1.
 This means that a web-application that was developed to run with JSTL
@@ -8264,11 +8258,7 @@ will simply be ignored as JSTL provided by the platform always takes
 precedence (see Section JSP.7.3.2, "TLD resource path" of the JSP
 specification).
 
-
-
-image:taglib-66.png[image]
-
-JSTL 1.1 Backwards Compatibility
+=== JSTL 1.1 Backwards Compatibility
 
 JSTL 1.1 is backwards compatible with JSTL 1.0.
 This means that a web-application that was developed to run with JSTL
@@ -8283,8 +8273,7 @@ that has JSTL 1.1, it is however recommended that you migrate to JSTL
 how to migrate your web-application from JSTL 1.0 to JSTL 1.1 are given
 in link:jstl.html#a3110[See Migrating to JSTL 1.1].
 
-[[a3089]]How JSTL 1.1 Backwards
-Compatibility is Achieved
+==== How JSTL 1.1 Backwards Compatibility is Achieved
 
 JSTL 1.0 requires JSP 1.2 (J2EE 1.3 platform).
 The key difference between JSTL 1.0 and JSTL 1.1 is that the expression
@@ -8348,46 +8337,34 @@ machinery must be explicitely disabled for the pages where the JSTL 1.0
 tag libraries are used. Consult the JSP specification for details.
 
 
-
-image:taglib-66.png[image]
-
-[[a3110]]Migrating to JSTL 1.1
+=== Migrating to JSTL 1.1
 
 To migrate from JSTL 1.0 to JSTL 1.1, so a web
 application can take advantage of the new features associated with JSTL
 1.1, one must do the following:
 
-Migrate the web application deployment
+* Migrate the web application deployment
 descriptor (web.xml) from servlet 2.3 to servlet 2.4.
 
-See Servlet 2.4 specification for details
+** See Servlet 2.4 specification for details
 
-Replace all the JSTL 1.0 EL & RT URIs by the new
+* Replace all the JSTL 1.0 EL & RT URIs by the new
 JSTL 1.1 URIs
 
-Escape all occurrences of “$\{“ in RT actions
+* Escape all occurrences of “$\{“ in RT actions
 and template text.
 
-See JSP 2.0 specification for details.
+** See JSP 2.0 specification for details.
 
-===  
+<<<
 
-=== 
-
-image:taglib-67.png[image]
-
-Changes
-
-image:taglib-68.png[image]
+[appendix]
+== Changes
 
 This appendix lists the
 changes in the JSTL specification. This appendix is non-normative.
 
-
-
-image:taglib-69.png[image]
-
-JSTL 1.2 Maintenance Release
+=== JSTL 1.2 Maintenance Release
 
 The goal of this maintenance release is to
 align the JSTL specification with the work done on the JavaServer Pages
@@ -8398,42 +8375,38 @@ platform.
 Iteration tags support for nested actions with
 deferred-values referring to the iteration variable
 
-The semantics of the standard actions
-<c:forEach> and <c:forTokens> are modified to allow the iteration tags
+* The semantics of the standard actions
+`<c:forEach>` and `<c:forTokens>` are modified to allow the iteration tags
 to work seamlessly with nested JavaServer Faces actions. More
-specifically, <c:forEach> and <c:forTokens> now support nested actions
+specifically, `<c:forEach>` and `<c:forTokens>` now support nested actions
 with deferred-values referring to the iteration variable, as long as a
 deferred value has been specified for the 'items' attribute. See
 link:jstl.html#a638[See <c:forEach>] and
 link:jstl.html#a713[See <c:forTokens>].
 
-<c:set> support for deferred values
+`<c:set>` support for deferred values
 
-The semantics of the standard action <c:set>
+* The semantics of the standard action `<c:set>`
 have been modified to allow the action to accept a deferred-value. See
 link:jstl.html#a335[See <c:set>].
 
 Generics
 
-Since JSP 2.1 requires J2SE 5.0, we’ve modified
+* Since JSP 2.1 requires J2SE 5.0, we’ve modified
 the APIs that can take advantage of generics:
 _ScriptFreeTLV:setInitParameters()_
 
 Minor corrections
 
-Example involving <fmt:parseDate> in section
+* Example involving `<fmt:parseDate>` in section
 9.9 was incorrect. A pattern has been added so the date can be parsed
 properly.
 
-Clarified the fact that the output of <c:url>
-won’t work for the _url_ attribute value of <c:import> for context
+* Clarified the fact that the output of <`c:url>`
+won’t work for the _url_ attribute value of `<c:import>` for context
 relative URLs (URLs that start with a '/'). (section 7.4).
 
-
-
-image:taglib-69.png[image]
-
-JSTL 1.1 Maintenance Release
+=== JSTL 1.1 Maintenance Release
 
 As already stated in the JSTL 1.0 specification,
 the specification of the Expression Language (EL) first introduced in
@@ -8446,25 +8419,25 @@ to the initial specification.
 Expression Language moved to the JSP
 specification
 
-Necessary changes have been made all across the
+* Necessary changes have been made all across the
 specification to reflect the fact that the Expression Language now
 belongs to the JSP specification (JSP 2.0). This includes having
 appendix A removed ("Appendix A - Expression Language Definition"), as
 well as having examples modified to take advantage of the fact that EL
 expressions can now be used in template text and do not require the use
-of the <c:out> action (unless the escapeXml or default features of
-<c:out> are required).
+of the `<c:out>` action (unless the escapeXml or default features of
+`<c:out>` are required).
 
 Compatibility and Migration
 
-New Appendix A provides information on
+* New Appendix A provides information on
 compatibility between different versions of JSTL, as well as on how to
 migrate a web application to take advantage of the new features of the
 latest JSTL release.
 
 Functions
 
-Since JSP 2.0 introduces EL functions, JSTL 1.1
+* Since JSP 2.0 introduces EL functions, JSTL 1.1
 defines a simple, standard set of functions that has been most often
 requested by page authors. This includes functions to get the size of a
 collection, as well as to perform common string manipulations. Functions
@@ -8472,43 +8445,43 @@ are defined in the new Chapter 15.
 
 Support for direct transfer from Reader -> out
 
-With JSP 2.0, displaying the content of a Reader
+* With JSP 2.0, displaying the content of a Reader
 object to "out" has been identified as an important use case, creating
 the need for a mechanism to handle a direct transfer from reader -> out.
-This is now provided as an extension of <c:out>.
+This is now provided as an extension of `<c:out>`.
 
 Default values
 
-New section 2.9 has been added to describe how
+* New section 2.9 has been added to describe how
 default values can be handled in a generic way in JSTL.
 
 end attribute < begin attribute in iterator
 actions
 
-The spec used to constrain the end attribute to
+* The spec used to constrain the end attribute to
 be greater than or equal to the begin attribute. It has now been relaxed
 to handle this situation according to common practices of modern
 programming languages (e.g. C++, Java, Perl). If end < begin, the loop
 will simply not be executed.
 
-Character encoding support in <c:import>
+Character encoding support in `<c:import>`
 
-The way character encoding is handled for
-<c:import> has been corrected in Section 7.4.
+* The way character encoding is handled for
+`<c:import>` has been corrected in Section 7.4.
 
 Semantics of locales
 
-Clarified the fact that the semantics of
+* Clarified the fact that the semantics of
 locales in JSTL are the same as the ones defined by the class
 _java.util.Locale_ (section 8.1). A consequence of this is that, as of
 J2SE 1.4, new language codes defined in ISO 639 (e.g. _he_ , _yi_ , _id_
 ) will be returned as the old codes (e.g. _iw_ , _ji_ , _in_ ).
 
-Correct the inconsistency between <fmt:message>
-and <fmt:formatXXX> when <fmt:message> is used with parametric
+Correct the inconsistency between `<fmt:message>`
+and `<fmt:formatXXX>` when `<fmt:message>` is used with parametric
 replacement and a locale-less localization context
 
-If the localization context does not have any
+* If the localization context does not have any
 locale, the locale of the java.text.MessageFormat is set to the locale
 returned by the formatting locale lookup algorithm in section 9.3,
 except that the available formatting locales are given as the
@@ -8518,48 +8491,48 @@ java.text.MessageFormat is set to the runtime's default locale.
 
 Null or empty values with formatting actions
 
-The behavior of <fmt:formatNumber> and
-<fmt:formatDate> (sections 9.7 and 9.9) has been clarified when value is
+* The behavior of `<fmt:formatNumber>` and
+`<fmt:formatDate>` (sections 9.7 and 9.9) has been clarified when value is
 null or empty.
 
 Connection handling in SQL actions
 
-Clarifications have been made to the fact that
+* Clarifications have been made to the fact that
 SQL actions in JSTL always release connections to the database as
 quickly as possible (a connection is always closed by the time execution
 of the action responsible for opening it completes).
 
 Context for XPath expression evaluations nested
-within <x:forEach>
+within `<x:forEach>`
 
-A new description subsection has been added to
+* A new description subsection has been added to
 Section 12.6 to clarify how the context for XPath expression evaluations
-is obtained within <x:forEach>.
+is obtained within `<x:forEach>`.
 
-Align behavior of <x:forEach> with <c:forEach>
+Align behavior of `<x:forEach>` with `<c:forEach>`
 
-Attributes _varStatus_ , _begin_ , _end_ , and
+* Attributes _varStatus_ , _begin_ , _end_ , and
 _step_ have been added.
 
 Default context node for XPath expression
 evaluations
 
-New section "11.1.6 Default Context Node"
+* New section "11.1.6 Default Context Node"
 clarifies how the default context node for XPath expression evaluations
 is obtained.
 
 Replace attributes that start with "xml"
 
-Names beginning with the string "xml" are
+* Names beginning with the string "xml" are
 reserved by the XML specification. New attribute _doc_ has been added to
-<x:parse> to replace attribute _xml_ that is now being deprecated. Also,
-new attributes _doc_ and _docSystemId_ have been added to <x:transform>
+`<x:parse>` to replace attribute _xml_ that is now being deprecated. Also,
+new attributes _doc_ and _docSystemId_ have been added to `<x:transform>`
 to replace attributes _xml_ and _xmlSystemId_ that are now being
 deprecated.
 
 Response Encoding
 
-The way formatting actions influence the
+* The way formatting actions influence the
 encoding of the response has been clarified in sections 8.4 and 8.10.
 Repeated calls to _ServletResponse.setLocale()_ will affect the
 character encoding of the response only if it has not already been set
@@ -8567,26 +8540,22 @@ explicitely.
 
 Java APIs
 
-The specification of the JSTL Java APIs is now
+* The specification of the JSTL Java APIs is now
 generated directly from the Javadoc of the reference implementation and
 is consolidated within its own chapter (Chapter 16).
 
 Minor corrections
 
- _status_ has been corrected with _varStatus_
+* _status_ has been corrected with _varStatus_
 in section 6.6.
 
-The resulting locale of examples 1 and 3 in
+* The resulting locale of examples 1 and 3 in
 Section 8.3.3 have been corrected.
 
-The syntax of <sql:dateParam> in Section 10.8
+* The syntax of `<sql:dateParam>` in Section 10.8
 has been corrected.
 
-
-
-image:taglib-69.png[image]
-
-Changes between Proposed Final Draft and Final Draft
+=== Changes between Proposed Final Draft and Final Draft
 
 Many typos and clarifications have been made to
 the specification. Clarifications and modifications worth noting
@@ -8594,135 +8563,131 @@ include:
 
 Preface
 
-Added typographical conventions.
+* Added typographical conventions.
 
 Chapter 2 - Conventions
 
-When an action is required to throw an
+* When an action is required to throw an
 exception, there were two choices when no root cause was involved:
 _JspException_ or _JspTagException_ . The specification has now
 standardized on _JspException_ everywhere in the spec (instead of
 _JspException_ in some places (with root cause), and _JspTagException_
 in some others (no root cause)).
 
-Clarified the proper handling of constraints in
+* Clarified the proper handling of constraints in
 section 2.7.
 
-Constants names now use “_” as word separators
+* Constants names now use “_” as word separators
 (e.g. FMT_FALLBACK_LOCALE)
 
 Chapter 3 - Expression Language Overview
 
-Fixed example featuring the _default_ attribute
+* Fixed example featuring the _default_ attribute
 in section 3.6.
 
 Chapter 4 - General-Purpose Actions
 
-Transparent conversion now supported on a value
+* Transparent conversion now supported on a value
 to be set as a bean property.
 
-Clarified behavior of <c:set> when _value_ is
-null, so it has the same semantics as <c:remove>.
+* Clarified behavior of `<c:set>` when _value_ is
+null, so it has the same semantics as `<c:remove>`.
 
-Clarified the behavior of <c:out> when _value_
+* Clarified the behavior of `<c:out>` when _value_
 is null.
 
 Chapter 6 - Iterator Actions
 
-Corrected the name of method _setStatus()_ to be
+* Corrected the name of method _setStatus()_ to be
 _setVarStatus()_ , as it should have been.
 
-Methods _next()_ , _hasNext()_ , _prepare()_ of
+* Methods _next()_ , _hasNext()_ , _prepare()_ of
 class _LoopTagSupport_ are abstract methods.
 
-Method _hasNext()_ of class _LoopTagSupport_
+* Method _hasNext()_ of class _LoopTagSupport_
 returns boolean.
 
-Added protected fields _beginSpecified_ ,
-_endSpecified_ , and _stepSpecified_ to class _LoopTagSupport_ .
+* Added protected fields _beginSpecified_ ,
+_endSpecified_ , and _stepSpecified_ to class _LoopTagSupport_.
 
 Chapter 8 - I18N Actions
 
-Left over references to
-_jakarta.servlet.jsp.jstl.fmt.bundle_ have been changed to
-_jakarta.servlet.jsp.jstl.fmt.localizationContext_ .
+* Left over references to
+_javax.servlet.jsp.jstl.fmt.bundle_ have been changed to
+_javax.servlet.jsp.jstl.fmt.localizationContext_.
 
-Added the three constructors to class
+* Added the three constructors to class
 _LocalizationContext_ and clarified the behavior of methods
-_getResourceBundle()_ and _getLocale()_ .
+_getResourceBundle()_ and _getLocale()_.
 
 Chapter 9 - Formatting Actions
 
-Clarified how the formatting pattern applies in
-<fmt:number> and <fmt:parseNumber>.
+* Clarified how the formatting pattern applies in
+`<fmt:number>` and `<fmt:parseNumber>`.
 
 Chapter 10 - SQL Actions
 
-Clarified the handling of auto-commit mode and
-isolation level in <sql:transaction>.
+* Clarified the handling of auto-commit mode and
+isolation level in `<sql:transaction>`.
 
-Clarified the handling of exceptions occurring
-during the execution of <sql:transaction>.
+* Clarified the handling of exceptions occurring
+during the execution of `<sql:transaction>`.
 
-Added clarification to <sql:param> when dealing
+* Added clarification to `<sql:param>` when dealing
 with _String_ values (only works for columns of text type).
 
-Clarified that if _dataSource_ is null, a
-_JspException_ is thrown for <sql:query>, <sql:update>,
-<sql:transaction>, and <sql:setDataSource>.
+* Clarified that if _dataSource_ is null, a
+_JspException_ is thrown for `<sql:query>`, `<sql:update>`,
+`<sql:transaction>`, and `<sql:setDataSource>`.
 
 Chapters 11, 12, 13 - XML Actions
 
-Clarified “Null & Error Handling” for <x:parse>
-and <x:transform>
+* Clarified “Null & Error Handling” for `<x:parse>`
+and `<x:transform>`
 
-In <x:forEach>, if _select_ is empty, a
+* In `<x:forEach>`, if _select_ is empty, a
 _JspException_ is now thrown.
 
-Added syntax without body content to <x:if>. It
-is now similar to <c:if>.
+* Added syntax without body content to `<x:if>`. It
+is now similar to `<c:if>`.
 
-Only _String_ and _Reader_ objects are now
-allowed for the _xml_ attribute of <x:parse>.
+* Only _String_ and _Reader_ objects are now
+allowed for the _xml_ attribute of `<x:parse>`.
 
-Clarified that DOM objects are supported as
+* Clarified that DOM objects are supported as
 XPath variables.
 
 Appendix A - Expression Language
 
-Alternative operators &&, ||, and ! were missing
+* Alternative operators &&, ||, and ! were missing
 in some of the tables. They now appear along with their counterpart and,
 or, and not.
 
-Clarified the definition of integer and floating
+* Clarified the definition of integer and floating
 point literals.
 
-Removed division by 0 as an example of exception
+* Removed division by 0 as an example of exception
 for arithmetic operators / and %.
 
-
-
-image:taglib-69.png[image]
-
-Changes between Public Draft and Proposed Final Draft
+=== Changes between Public Draft and Proposed Final Draft
 
 Many typos and clarifications have been made to
 the specification. Major changes include:
 
 Preface
 
-Added acknowledgements.
+* Added acknowledgements.
 
 Chapter 1 - Introduction
 
-Clarified the fact that actions from EL- and RT-
+* Clarified the fact that actions from EL- and RT-
 based libraries can be mixed together.
 
 Chapter 2 - Conventions
 
-Clarified how actions throw exceptions.
+* Clarified how actions throw exceptions.
 
-“Section 2.8 - Configuration Parameters” has
+* “Section 2.8 - Configuration Parameters” has
 been completely rewritten and is now titled “Configuration Data”. The
 way configuration data is handled in JSTL has been clarified and will
 now work properly with containers that implement JSP scopes via a single
@@ -8730,171 +8695,171 @@ namespace.
 
 Chapter 4 - Expression Language Support Actions
 
-Renamed the chapter to “General Purpose
+* Renamed the chapter to “General Purpose
 Actions”.
 
-Removed the restriction that the actions in this
+* Removed the restriction that the actions in this
 chapter are only available in the EL-based version of the library.
 
-Extended the scope of <c:set> so it supports
+* Extended the scope of `<c:set>` so it supports
 setting a property of a target JavaBeans or _java.util.Map_ object.
 
 Chapter 7 - URL Related Actions
 
-Improved the error handling behavior of
-<c:import>
+* Improved the error handling behavior of
+`<c:import>`
 
-<c:url> and <c:redirect> now append the context
+* `<c:url>` and `<c:redirect>` now append the context
 path to any relative URL that starts with "/". Added new attribute
 _context_ to properly handle foreign context URLs.
 
 Chapter 8 - I18N Actions
 
-In the resource bundle lookup, the locale-less
+* In the resource bundle lookup, the locale-less
 root resource bundle is now supported if neither the preferred locales
 nor the fallback locale yield a resource bundle match.
 
-<fmt:locale> has been renamed to
-<fmt:setLocale>.
+* `<fmt:locale>` has been renamed to
+`<fmt:setLocale>`.
 
-<fmt:bundle> no longer takes 'var' and 'scope'.
+* `<fmt:bundle>` no longer takes 'var' and 'scope'.
 Creating and storing an I18N localization context with a resource bundle
 in a 'var' or scoped configuration variable is now done by the new
-<fmt:setBundle>.
+`<fmt:setBundle>`.
 
-Logging is considered an implementation-specific
+* Logging is considered an implementation-specific
 (deployment) issue and has been removed from <fmt:message>'s
 description.
 
-A new class _LocalizationContext_ has been
+* A new class _LocalizationContext_ has been
 defined which represents an I18N localization context containg a
-_java.util.ResourceBundle_ and a _java.util.Locale_ .
+_java.util.ResourceBundle_ and a _java.util.Locale_.
 
- _jakarta.servlet.jsp.jstl.fmt.basename_ has been
-replaced with _jakarta.servlet.jsp.jstl.fmt.localizationContext_ .
+* _java.servlet.jsp.jstl.fmt.basename_ has been
+replaced with _java.servlet.jsp.jstl.fmt.localizationContext_.
 
 Chapter 9 - Formatting Actions
 
-Formatting actions nested inside a <fmt:bundle>
+* Formatting actions nested inside a `<fmt:bundle>`
 no longer use that bundle's locale as their formatting locale, but the
 locale of the enclosing I18N localization context, which is the
 (possibly more specific) locale that led to the resource bundle match.
 
-<fmt:timeZone> no longer takes 'var' and
+* `<fmt:timeZone>` no longer takes 'var' and
 'scope'. Storing a time zone in a 'var' or scoped configuration variable
-is now done by the new <fmt:setTimeZone>.
+is now done by the new `<fmt:setTimeZone>`.
 
-<fmt:formatNumber> no longer uses the "en"
+* `<fmt:formatNumber>` no longer uses the "en"
 locale to parse numeric values given as strings, but uses Long.valueOf()
 or Double.valueOf() instead.
 
-In <fmt:parseNumber>, _parseLocale_ , which used
+* In `<fmt:parseNumber>`, _parseLocale_ , which used
 to support string values only, now also supports values of type
-_java.util.Locale_ .
+_java.util.Locale_.
 
-<fmt:formatDate> no longer supports literal
+* `<fmt:formatDate>` no longer supports literal
 values, and no longer has a body. Its 'value' attribute is no longer
 optional, meaning the default behaviour of formatting the current time
 and date is no longer supported.
 
-In <fmt:parseDate>, _parseLocale_ , which used
+* In `<fmt:parseDate>`, _parseLocale_ , which used
 to support string values only, now also supports values of type
-_java.util.Locale_ .
+_java.util.Locale_.
 
-<fmt:setLocale>, formerly known as <fmt:locale>,
+* `<fmt:setLocale>`, formerly known as `<fmt:locale>`,
 now also accepts values of type _java.util.Locale_ (in addition to
 string values).
 
-The runtime's default locale is no longer used
+* The runtime's default locale is no longer used
 as a fallback, since it is not guaranteed to be among the supported
 formatting locales.
 
-<fmt:timeZone> and the new <fmt:setTimeZone> now
+* `<fmt:timeZone>` and the new `<fmt:setTimeZone>` now
 also accept values of type _java.util.TimeZone_ (in addition to string
 values).
 
 Chapter 10 - SQL Actions
 
-The configuration settings now include JDBC
+* The configuration settings now include JDBC
 parameters.
 
-<sql:driver> has been renamed
-<sql:setDataSource>. It now supports attribute “password” as well as
+* `<sql:driver>` has been renamed
+`<sql:setDataSource>`. It now supports attribute “password” as well as
 setting configuration variables.
 
-The keys in the Map objects returned by
+* The keys in the Map objects returned by
 Result.getRows() are now case-insensitive. The motivation for this
 change is that some databases return column names as all-uppercase
 strings in the ResultSet, while others return them with the same
 upper/lowercase mix as was used in the SELECT statement.
 
-Method _Result.getRowsCount()_ has been renamed
+* Method _Result.getRowsCount()_ has been renamed
 to _Result.getRowCount()_ to be compatible with naming conventions in
 J2SE.
 
-Method _Result.getMetaData()_ as well as
+* Method _Result.getMetaData()_ as well as
 interface _ColumnMetaData_ have been removed because handling of
 exceptions encountered when caching _ResultSetMetaData_ is problematic.
 New method _Result.getColumnNames()_ has been added to still provide
 easy access to column names.
 
-Exception message for <sql:query> and
-<sql:update> has been improved. It now includes the SQL statement and
+* Exception message for `<sql:query>` and
+`<sql:update>` has been improved. It now includes the SQL statement and
 provides the caught exception as the root cause.
 
-Warning added in <sql:transaction> about the use
+* Warning added in `<sql:transaction>` about the use
 of commit and rollback.
 
-JNDI resource path to a data source must now be
+* JNDI resource path to a data source must now be
 specified as a relative path, just as is the case in a J2EE deployment
 descriptor.
 
-New <sql:dateParam> action added to properly
+* New `<sql:dateParam>` action added to properly
 support setting the values of parameter markers for values of type
-_java.util.Date_ .
+_java.util.Date_.
 
-The algorithm used by the SQL actions
-(<sql:query>, <sql:update>, <sql:transaction>) to access a database has
+* The algorithm used by the SQL actions
+(`<sql:query>`, `<sql:update>`, `<sql:transaction>`) to access a database has
 been modified to support configuration settings for a dataSource as well
 as for the JDBC DriverManager facility.
 
 Chapters 11, 12, 13 - XML Actions
 
-Removed the syntax with body content for
-<x:set>. This was introducing a potentially confusing mechanism for
+* Removed the syntax with body content for
+`<x:set>`. This was introducing a potentially confusing mechanism for
 entering "dynamic" XPath expressions.
 
-URLs specified in <x:parse> and <x:transform>
+* URLs specified in `<x:parse>` and `<x:transform>`
 may now be absolute or relative URLs.
 
-Clarified the fact that <x:parse> and
-<x:transform> do not perform any validation against DTD's or Schemas.
+* Clarified the fact that `<x:parse>` and
+`<x:transform>` do not perform any validation against DTD's or Schemas.
 
-XPath scopes “page”, “request”, “session”, and
+* XPath scopes “page”, “request”, “session”, and
 “application” have been renamed “pageScope”, “requestScope”,
 “sessionScope”, and “applicationScope” to be the same as the names of
 implicit objects in the expression language.
 
 Appendix A - Expression Language
 
-Implicit objects _page_ , _request_ , _session_
+* Implicit objects _page_ , _request_ , _session_
 , _application_ , have been renamed _pageScope_ , _requestScope_ ,
-_sessionScope_ , _applicationScope_ .
+_sessionScope_ , _applicationScope_.
 
-Implicit object _params_ has been renamed
-_paramValues_ .
+* Implicit object _params_ has been renamed
+_paramValues_.
 
-Added implicit objects _header_ , _headerValues_
-, _cookie_ , and _initParam_ .
+* Added implicit objects _header_ , _headerValues_
+, _cookie_ , and _initParam_.
 
-Coercion rules have been improved.
+* Coercion rules have been improved.
 
-New operator “empty” has been added.
+* New operator “empty” has been added.
 
-“eq” and “ne” have been added as alternatives to
+* “eq” and “ne” have been added as alternatives to
 “==” and “!=”
 
-“&&”, “||”, “!” have been added as alternatives
+* “&&”, “||”, “!” have been added as alternatives
 to “and”, “or”, and “not”.
 
 '''''
@@ -8951,11 +8916,11 @@ responsible for setting the data source in a transaction.
 
 [.footnoteNumber]# 10.# [[a3277]]Deprecated.
 
-=== [.footnoteNumber]# 11.# [[a3278]]Names beginning with the string "xml" are reserved by the XML specification.
+[.footnoteNumber]# 11.# [[a3278]]Names beginning with the string "xml" are reserved by the XML specification.
 
 [.footnoteNumber]# 12.# [[a3279]]Deprecated.
 
-=== [.footnoteNumber]# 13.# [[a3280]]Names beginning with the string "xml" are reserved by the XML specification.
+[.footnoteNumber]# 13.# [[a3280]]Names beginning with the string "xml" are reserved by the XML specification.
 
 [.footnoteNumber]# 14.# [[a3281]]Note that the support
 in <c:forEach> for strings representing lists of coma separated values

--- a/oracle-spec/src/main/asciidoc/TagLibrary.adoc
+++ b/oracle-spec/src/main/asciidoc/TagLibrary.adoc
@@ -6521,15 +6521,15 @@ character conversions are applied:
 |===
 |Character
 |Character Entity Code
-| _<_ | +&lt;+
+| _<_ | \&lt;
 
-| _>_ | +&gt;+
+| _>_ | \&gt;
 
-| _&_ | +&amp;+
+| _&_ | \&amp;
 
-|‘ |+&#039;+
+|‘ |\&#039;
 
-|‘’ |+&#034;+
+|‘’ |\&#034;
 |===
 
 <<<


### PR DESCRIPTION
Updated Appendix A: Compatibility & Migration

Updated Appendix B: Changes

Minor updates to escape consistently: 57f87f8070a8b56f22c5780ca9042491b63088c2 

**A couple of comments for review:**
1) https://github.com/eclipse-ee4j/jstl-api/pull/67/files#diff-f4d9c256d378f7473b54eec8cfa8ca67L8773 I changed this back to `javax` from `jakarta` as I think this was a bad find/replace from the initial specification as this is in the original changelog
2)  https://github.com/eclipse-ee4j/jstl-api/pull/67/files#diff-f4d9c256d378f7473b54eec8cfa8ca67L8647 also changed back to javax
