### PR TITLE
Expand acronyms that are not allowed in API javadoc

### DIFF
--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTag.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTag.java
@@ -20,9 +20,9 @@ package jakarta.servlet.jsp.jstl.core;
 import jakarta.servlet.jsp.tagext.Tag;
 
 /**
- * <p>JSTL allows developers to write custom iteration tags by
+ * <p>The Jakarta Standard Tag Library allows developers to write custom iteration tags by
  * implementing the LoopTag interface.  This is not to be confused
- * with <tt>jakarta.servlet.jsp.tagext.IterationTag</tt> as defined in JSP 1.2.
+ * with <tt>jakarta.servlet.jsp.tagext.IterationTag</tt> as defined in Jakarta Server Pages 1.2.
  * LoopTag establishes a mechanism for iteration tags to be recognized
  * and for type-safe implicit collaboration with custom subtags.
  * 

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTagStatus.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTagStatus.java
@@ -19,7 +19,7 @@ package jakarta.servlet.jsp.jstl.core;
 
 /**
  * <p>Exposes the current status of
- * an iteration.  JSTL provides a mechanism for LoopTags to
+ * an iteration.  The Jakarta Standard Tag Library provides a mechanism for LoopTags to
  * return information about the current index of the iteration and
  * convenience methods to determine whether or not the current round is
  * either the first or last in the iteration.  It also lets authors

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTagSupport.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTagSupport.java
@@ -95,7 +95,7 @@ public abstract class LoopTagSupport
     /**
      * Ending index of the iteration ('end' attribute).
      * A value of -1 internally indicates 'no end
-     * specified', although accessors for the core JSTL tags do not
+     * specified', although accessors for the core Jakarta Standard Tag Library tags do not
      * allow this value to be supplied directly by the user.
      */
     protected int end;
@@ -235,7 +235,6 @@ public abstract class LoopTagSupport
      */
     public int doStartTag() throws JspException {
         if (end != -1 && begin > end) {
-            // JSTL 1.1. We simply do not execute the loop.
             return SKIP_BODY;
         }
 

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTagSupport.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTagSupport.java
@@ -38,7 +38,7 @@ import jakarta.servlet.jsp.tagext.TryCatchFinally;
  * <p>Base support class to facilitate implementation of iteration tags.</p>
  *
  * <p>Since most iteration tags will behave identically with respect to
- * actual iterative behavior, JSTL provides this
+ * actual iterative behavior, the Jakarta Standard Tag Library provides this
  * base support class to facilitate implementation.  Many iteration tags
  * will extend this and merely implement the <tt>hasNext()</tt> and 
  * <tt>next()</tt> methods

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/package.html
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/package.html
@@ -23,14 +23,14 @@
 </head>
 <body bgcolor="white">
 
-Classes and interfaces related to the <i>core tag library</i> component of the JavaServer Pages Standard Tag Library (JSTL).
+Classes and interfaces related to the <i>core tag library</i> component of the Jakarta Standard Tag Library.
 
 <p> This tag library component provides:
 <ul>
   <li>General-purpose tags for the manipulation of scoped variables and handling of error conditions
-  <li>Conditional tags for the conditional processing of a JSP page
+  <li>Conditional tags for the conditional processing of a Jakarta Server Pages page
   <li>Iterator tags for iterating over a wide variety of objects
-  <li>URL-related tags for linking or redirecting to URL resources from a JSP page, or importing a URL resource into a JSP page
+  <li>URL-related tags for linking or redirecting to URL resources from a Jakarta Server Pages page, or importing a URL resource into a Jakarta Server Pages page
 </ul>
 </body>
 </html>

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/fmt/package.html
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/fmt/package.html
@@ -23,8 +23,8 @@
 </head>
 <body bgcolor="white">
 
-Classes and interfaces related to the <i>locale sensitive formatting tag library</i> component of the JavaServer Pages Standard Tag Library (JSTL).
+Classes and interfaces related to the <i>locale sensitive formatting tag library</i> component of the Jakarta Standard Tag Library.
 
-<p> This tag library component provides a number of formatting tags which allow numbers, dates, and times in a JSP page to be formatted and parsed in a locale-sensitive or customized manner.
+<p> This tag library component provides a number of formatting tags which allow numbers, dates, and times in a Jakarta Server Pages page to be formatted and parsed in a locale-sensitive or customized manner.
 </body>
 </html>

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/sql/ResultImpl.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/sql/ResultImpl.java
@@ -30,7 +30,7 @@ import java.util.TreeMap;
  * <p>This class creates a cached version of a <tt>ResultSet</tt>.
  * It's represented as a <tt>Result</tt> implementation, capable of 
  * returing an array of <tt>Row</tt> objects containing a <tt>Column</tt> 
- * instance for each column in the row.   It is not part of the JSTL
+ * instance for each column in the row.   It is not part of the Jakarta Standard Tab Library
  * API; it serves merely as a back-end to ResultSupport's static methods.
  * Thus, we scope its access to the package.
  *

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/sql/package.html
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/sql/package.html
@@ -23,7 +23,7 @@
 </head>
 <body bgcolor="white">
 
-Classes and interfaces related to the <i>sql tag library</i> component of the JavaServer Pages Standard Tag Library (JSTL).
+Classes and interfaces related to the <i>sql tag library</i> component of the Jakarta Standard Tag Library.
 
 <p> This tag library component provides a number of SQL tags which provide basic capabilities to interact with relational databases.
 </body>

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/package.html
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/package.html
@@ -23,11 +23,11 @@
 </head>
 <body bgcolor="white">
 
-Reusable Tag Library Validator (TLV) classes provided by the JavaServer Pages Standard Tag Library (JSTL).
+Reusable Tag Library Validator (TLV) classes provided by the Jakarta Standard Tag Library.
 
-<p>TLVs allow translation-time validation of the XML view of a JSP page. The TLVs provided by JSTL allow tag library authors to enforce restrictions regarding the use of scripting elements and permitted tag libraries in JSP pages.
+<p>TLVs allow translation-time validation of the XML view of a Jakarta Server Pages page. The TLVs provided by the Jakarta Standard Tag Library allow tag library authors to enforce restrictions regarding the use of scripting elements and permitted tag libraries in Jakarta Server Pages.
 
-<p>For example, any JSP page that imports the tag library with the following Tag Library Descriptor (TLD) file will be restricted to using JSTL tags:
+<p>For example, any Jakarta Server Pages page that imports the tag library with the following Tag Library Descriptor (TLD) file will be restricted to using Jakarta Standard Tag Library tags:
 
 <pre>
 &lt;?xml version="1.0" encoding="UTF-8" ?&gt;


### PR DESCRIPTION
There are a number of occurrences of acronyms that are not allowed in the API JavaDocs. This is a first pass at those changes.

@arjantijms  any idea how we should handle references to previously released versions such as 1.1?

For instance we have the following in LoopTagSupport.java:

> // JSTL 1.1. We simply do not execute the loop.

Even though there was not a Jakarta Standard Tag Library 1.1 release should we still update this in the same way? If so I'll make an additional change before merging this PR.