### PR TITLE
Update the API JavaDoc License

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -266,7 +266,7 @@
                             <bottom><![CDATA[
 Comments to: <a href="mailto:jstl-dev@eclipse.org">jstl-dev@eclipse.org</a>.<br>
 Copyright &#169; 2019, 2020 Eclipse Foundation. All rights reserved.<br>
-Use is subject to <a href="{@docRoot}/doc-files/speclicense.html" target="_top">license terms</a>.]]>
+Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
                             </bottom>
                             <docfilessubdirs>true</docfilessubdirs>
                             <groups>

--- a/api/src/main/javadoc/doc-files/EFSL.html
+++ b/api/src/main/javadoc/doc-files/EFSL.html
@@ -20,8 +20,9 @@
   <li>All existing copyright notices, or if one does not exist, a notice
       (hypertext is preferred, but a textual representation is permitted)
       of the form: &quot;Copyright &copy; [$date-of-document]
-      &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
-      &quot;
+      Eclipse Foundation, Inc. 
+	  <a href="https://www.eclipse.org/legal/efsl.php">
+	  https://www.eclipse.org/legal/efsl.php</a>&quot;
   </li>
 </ul>
 
@@ -42,9 +43,11 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
-  document includes material copied from or derived from [title and URI
-  of the Eclipse Foundation specification document].&quot;</p>
+<p>&quot;Copyright &copy; 2018, 2020 Eclipse Foundation. This software or
+  document includes material copied from or derived from Jakarta&reg; 
+  Standard Tag Library 
+  <a href="https://jakarta.ee/specifications/tags/2.0/">
+  https://jakarta.ee/specifications/tags/2.0/</a>.&quot;</p>
 
 <h2>Disclaimers</h2>
 


### PR DESCRIPTION
This is the work for the Javadoc portion of : https://github.com/eclipse-ee4j/jstl-api/issues/56

I also renamed the the file from speclicense.html to EFSL.html which is what the issue expected and what looks to be available in other API projects just as the Expression Language and Jakarta Server Pages.

Updated the API pom.xml to use the new file name.

As a note line 23 of the license contained the following quote which was out of place when rendering the page and when looking at the other projects such as Expression Language and Jakarta Server Pages: `&ldquo;Eclipse Foundation,` I removed it in the updates.