### PR TITLE
Revert API updates in Poms until available

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -99,12 +99,12 @@
         <dependency>
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
-            <version>4.0.0</version>
+            <version>4.0.0-RC2</version>
         </dependency>
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>
-            <version>3.0.0</version>
+            <version>3.0.0-RC3</version>
         </dependency>
     </dependencies>
 

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -100,13 +100,13 @@
         <dependency>
             <groupId>jakarta.el</groupId>
             <artifactId>jakarta.el-api</artifactId>
-            <version>4.0.0</version>
+            <version>4.0.0-RC2</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet.jsp.jstl</groupId>
             <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-            <version>2.0.0-RC3</version>
+            <version>2.0.0-RC1</version>
         </dependency>
         <dependency>
             <groupId>xalan</groupId>


### PR DESCRIPTION
Reverting the api version updates made in : https://github.com/eclipse-ee4j/jstl-api/pull/89 until they are available.