### PR TITLE
Initial footnote updates in spec document.

### DIFF
--- a/spec/src/main/asciidoc/jakarta-stl.adoc
+++ b/spec/src/main/asciidoc/jakarta-stl.adoc
@@ -415,11 +415,11 @@ categorized as either nested or at-end.
 
 _Nested_ scoped variables are only
 visible within the body of the action and are stored in "page"
-scopelink:#a3268[1]. The action must create the variable
+scopefootnote:[Since nested scoped variables are always saved in page scope, no scope attribute is associated with them.]. The action must create the variable
 according to the semantics of _PageContext.setAttribute(varName,
 PAGE_SCOPE)_ , and it must remove it at the end of the action according
 to the semantics of _PageContext.removeAttribute(varName, PAGE_SCOPE)_
-.link:#a3269[2]
+.footnote:[It is important to note that the Jakarta Server Pages specification says that "A name should refer to a unique object at all points in the execution, that is all the different scopes really should behave as a single name space." The Jakarta Server Pages specification also says that "A JSP container implementation may or may not enforce this rule explicitly due to performance reasons". Because of this, if a scoped variable with the same name as a nested variable already exists in a scope other than 'page', exactly what happens to that scoped variable depends on how the Jakarta Server Pages container has been implemented. To comply with the Jakarta Server Pages specification, and to avoid non-portable behavior, page authors should therefore avoid using the same name in different scopes.]
 
 At-end scoped variables are only visible at
 the end of the action. Their lifecycle is the one associated with their
@@ -1746,7 +1746,7 @@ they should not be used within more than one iteration tag.
 *Deprecated*: Finally,
 _java.lang.String_ objects can be iterated over if the string represents
 a list of comma separated values (e.g.
-“Monday,Tuesday,Wednesday,Thursday,Friday”).link:#a3270[3]
+“Monday,Tuesday,Wednesday,Thursday,Friday”).footnote:[The proper way to process strings of tokens is via <c:forTokens> or via functions _split_ and _join_.]
 
 Absent from the list of supported types is
 _java.sql.ResultSet_ (which includes _jakarta.sql.RowSet_ ). The reason
@@ -2494,10 +2494,10 @@ comes with some restrictions.
 It is the responsibility of the `<c:import>`
 tag handler to ensure that if it exports a _Reader_ , this _Reader_ is
 properly closed by the time the end of the page is
-reachedlink:#a3271[4]. Because of this requirement, the Jakarta Standard Tag Library defines
+reachedfootnote:[If the responsibility was left to the consumer tag, this could lead to resource leaks (e.g. connection left open, memory space for buffers) until garbage collection is activated. This is because a consumer tag might not close the _Reader_ , or because the page author might remove the consumer tag while leaving inadvertantly the <c:import> tag in the page.]. Because of this requirement, the Jakarta Standard Tag Library defines
 the exported _Reader_ as having nested visibility: it may not currently
 be accessed after the end-tag for the `<c:import>`
-actionlink:#a3272[5]. Implementations that use JSP 1.2
+actionfootnote:[This restriction could eventually be lifted when the JSP spec supports the notion of page events that actions could register to. On a _pageExit_ event, an <c:import> tag would then simply release its resources if it had not already been done, removing the requirement for nested visibility.]. Implementations that use JSP 1.2
 tag-extension API will likely need to implement _TryCatchFinally_ with
 their `<c:import>` tag handlers and close the exported Reader in
 _doFinally()_ .
@@ -2509,7 +2509,7 @@ established within the start element of the action. It is therefore
 impossible for nested `<c:param>` actions to modify the URL of the
 resource to be accessed, thus their illegality with syntax 2. In such a
 situation, `<c:url>` may be used to build a URL with query string
-parameterslink:#a3273[6]. `<c:import>` will remove any session id
+parametersfootnote:[It is however important to note that using the output of <c:url> as the _url_ attribute value of <c:import> won't work for context relative URLs (URLs that start with a '/'). That’s because in those cases <c:url> prepends the context path to the URL value.]. `<c:import>` will remove any session id
 information if necessary (see <<c:url>>).
 
 .*Character Encoding*
@@ -2936,7 +2936,7 @@ internationalization: locale, resource bundle, and basename.
 
 A locale represents a specific geographical,
 political, or cultural region. A locale is identified by a language
-code, along with an optional country codelink:#a3274[7].
+code, along with an optional country codefootnote:[A variant code may also be specified, although rarely used.].
 
 * Language code +
 The language code is the lower-case
@@ -4072,7 +4072,7 @@ and time are formatted in the “GMT+1:00” time zone:
 
 === Formatting Locale
 
-A formatting actionlink:#a3275[8] may
+A formatting actionfootnote:[Four formatting actions localize their data: <fmt:formatNumber>, <fmt:parseNumber>, <fmt:formatDate>, <fmt:parseDate>.] may
 leverage an i18n localization context to determine its formatting locale
 or establish a formatting locale on its own, by following these steps:
 
@@ -5399,7 +5399,7 @@ _var_.
 
 * If _dataSource_ is specified, this
 action must not be nested inside a
-<sql:transaction>.link:#a3276[9]
+<sql:transaction>.footnote:[<sql:transaction> is responsible for setting the data source in a transaction.]
 
 * _maxRows_ must be >= -1
 
@@ -6358,7 +6358,7 @@ content, then the action trims it and processes it further.
 
 | _xml_ | _true_
 | _String, Reader_
-| _Deprecatedlink:#a3278[11]_ . Use
+| _Deprecated_ footnote:[Names beginning with the string "xml" are reserved by the XML specification.]. Use
 attribute _doc_ instead.
 
 |systemId |true
@@ -7043,7 +7043,7 @@ well-formed XML document, not a partial document.)
 | _String, Reader,
 jakarta.xml.transform.Source, org.w3c.dom.Document, or object exported by
 <x:parse>, <x:set>_ . |
-_Deprecatedlink:#a3280[13]_ . Use attribute _doc_ instead.
+_Deprecated_ footnote:[Names beginning with the string "xml" are reserved by the XML specification.]. Use attribute _doc_ instead.
 
 | _xslt_ | _true_
 | _String, Reader or
@@ -7320,7 +7320,7 @@ language.
 The _length_ function has been designed to be
 very similar to the use of "length" in EcmaScript. It can be applied to
 any object supported by the Jakarta Standard Tag Library iteration action
-<c:forEach>link:#a3281[14] and returns the length of the
+<c:forEach>footnote:[Note that the support in <c:forEach> for strings representing lists of coma separated values has been deprecated. The proper way to process strings of tokens is via <c:forTokens> or via functions _split_ and _join_.] and returns the length of the
 collection. When applied to a String, it returns the number of
 characters in the string.
 
@@ -8348,65 +8348,6 @@ changes in the JSTL specification. This appendix is non-normative.
 
 '''''
 
-[.footnoteNumber]# 1.# [[a3268]]Since nested scoped
-variables are always saved in page scope, no scope attribute is
-associated with them.
-
-[.footnoteNumber]# 2.# [[a3269]]It is important to
-note that the JSP specification says that "A name should refer to a
-unique object at all points in the execution, that is all the different
-scopes really should behave as a single name space." The JSP
-specification also says that "A JSP container implementation may or may
-not enforce this rule explicitly due to performance reasons". Because of
-this, if a scoped variable with the same name as a nested variable
-already exists in a scope other than 'page', exactly what happens to
-that scoped variable depends on how the JSP container has been
-implemented. To comply with the JSP specification, and to avoid
-non-portable behavior, page authors should therefore avoid using the
-same name in different scopes.
-
-[.footnoteNumber]# 3.# [[a3270]]The proper way to
-process strings of tokens is via <c:forTokens> or via functions _split_
-and _join_ .
-
-[.footnoteNumber]# 4.# [[a3271]]If the responsibility
-was left to the consumer tag, this could lead to resource leaks (e.g.
-connection left open, memory space for buffers) until garbage collection
-is activated. This is because a consumer tag might not close the
-_Reader_ , or because the page author might remove the consumer tag
-while leaving inadvertantly the <c:import> tag in the page.
-
-[.footnoteNumber]# 5.# [[a3272]]This restriction could
-eventually be lifted when the JSP spec supports the notion of page
-events that actions could register to. On a _pageExit_ event, an
-<c:import> tag would then simply release its resources if it had not
-already been done, removing the requirement for nested visibility.
-
-[.footnoteNumber]# 6.# [[a3273]]It is however
-important to note that using the output of <c:url> as the _url_
-attribute value of <c:import> won't work for context relative URLs (URLs
-that start with a '/'). That’s because in those cases <c:url> prepends
-the context path to the URL value.
-
-[.footnoteNumber]# 7.# [[a3274]]A variant code may
-also be specified, although rarely used.
-
-[.footnoteNumber]# 8.# [[a3275]]Four formatting
-actions localize their data: <fmt:formatNumber>, <fmt:parseNumber>,
-<fmt:formatDate>, <fmt:parseDate>.
-
-[.footnoteNumber]# 9.# [[a3276]]<sql:transaction> is
-responsible for setting the data source in a transaction.
-
 [.footnoteNumber]# 10.# [[a3277]]Deprecated.
 
-[.footnoteNumber]# 11.# [[a3278]]Names beginning with the string "xml" are reserved by the XML specification.
-
 [.footnoteNumber]# 12.# [[a3279]]Deprecated.
-
-[.footnoteNumber]# 13.# [[a3280]]Names beginning with the string "xml" are reserved by the XML specification.
-
-[.footnoteNumber]# 14.# [[a3281]]Note that the support
-in <c:forEach> for strings representing lists of coma separated values
-has been deprecated. The proper way to process strings of tokens is via
-<c:forTokens> or via functions _split_ and _join_ .


### PR DESCRIPTION
There are a number of footnotes that needed to be corrected / updated in the specification document.

I've left a couple to be done at a later date as it looks like they are in some of the syntax sections and those need to be reworked a bit differently.

1) [.footnoteNumber]# 10.# [[a3277]]Deprecated.
2) [.footnoteNumber]# 12.# [[a3279]]Deprecated.

In addition we'll need to update the quotes of the Jakarta Server Pages specification and ensure that they are correct, currently they use the JSP acronym.

> .footnote:[It is important to note that the Jakarta Server Pages specification says that "A name should refer to a unique object at all points in the execution, that is all the different scopes really should behave as a single name space." The Jakarta Server Pages specification also says that "A **JSP** container implementation may or may not enforce this rule explicitly due to performance reasons". Because of this, if a scoped variable with the same name as a nested variable already exists in a scope other than 'page', exactly what happens to that scoped variable depends on how the Jakarta Server Pages container has been implemented. To comply with the Jakarta Server Pages specification, and to avoid non-portable behavior, page authors should therefore avoid using the same name in different scopes.]