### PR TITLE
Formatting/cleaning according to Jakarta/EE4J conventions

### DIFF
--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/ConditionalTagSupport.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/ConditionalTagSupport.java
@@ -23,62 +23,56 @@ import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.tagext.TagSupport;
 
 /**
- * <p>Abstract class that facilitates implementation of conditional actions 
- * where the boolean result is exposed as a JSP scoped variable. The 
- * boolean result may then be used as the test condition in a &lt;c:when&gt;
- * action.</p>
+ * <p>
+ * Abstract class that facilitates implementation of conditional actions where the boolean result is exposed as a JSP
+ * scoped variable. The boolean result may then be used as the test condition in a &lt;c:when&gt; action.
+ * </p>
  *
- * <p>This base class provides support for:</p>
- * 
+ * <p>
+ * This base class provides support for:
+ * </p>
+ *
  * <ul>
- *  <li> Conditional processing of the action's body based on the returned value
- *       of the abstract method <tt>condition()</tt>.</li>
- *  <li> Storing the result of <tt>condition()</tt> as a <tt>Boolean</tt> object
- *       into a JSP scoped variable identified by attributes <tt>var</tt> and
- *       <tt>scope</tt>.
+ * <li>Conditional processing of the action's body based on the returned value of the abstract method
+ * <tt>condition()</tt>.</li>
+ * <li>Storing the result of <tt>condition()</tt> as a <tt>Boolean</tt> object into a JSP scoped variable identified by
+ * attributes <tt>var</tt> and <tt>scope</tt>.
  * </ul>
- * 
+ *
  * @author Shawn Bayern
  */
-
-public abstract class ConditionalTagSupport
-    extends TagSupport
-{
-    //*********************************************************************
+public abstract class ConditionalTagSupport extends TagSupport {
+    // *********************************************************************
     // Abstract methods
 
     /**
-     * <p>Subclasses implement this method to compute the boolean result
-     * of the conditional action. This method is invoked once per tag invocation 
-     * by <tt>doStartTag()</tt>.
+     * <p>
+     * Subclasses implement this method to compute the boolean result of the conditional action. This method is invoked once
+     * per tag invocation by <tt>doStartTag()</tt>.
      *
-     * @return a boolean representing the condition that a particular subclass
-     *   uses to drive its conditional logic.
+     * @return a boolean representing the condition that a particular subclass uses to drive its conditional logic.
      */
     protected abstract boolean condition() throws JspTagException;
 
-
-    //*********************************************************************
+    // *********************************************************************
     // Constructor
 
     /**
-     * Base constructor to initialize local state.  As with <tt>TagSupport</tt>,
-     * subclasses should not implement constructors with arguments, and
-     * no-argument constructors implemented by subclasses must call the 
-     * superclass constructor.
+     * Base constructor to initialize local state. As with <tt>TagSupport</tt>, subclasses should not implement constructors
+     * with arguments, and no-argument constructors implemented by subclasses must call the superclass constructor.
      */
     public ConditionalTagSupport() {
         super();
         init();
     }
 
-
-    //*********************************************************************
+    // *********************************************************************
     // Lifecycle management and implementation of conditional behavior
 
     /**
      * Includes its body if <tt>condition()</tt> evaluates to true.
      */
+    @Override
     public int doStartTag() throws JspException {
 
         // execute our condition() method once per invocation
@@ -88,39 +82,39 @@ public abstract class ConditionalTagSupport
         exposeVariables();
 
         // handle conditional behavior
-        if (result)
+        if (result) {
             return EVAL_BODY_INCLUDE;
-        else
+        } else {
             return SKIP_BODY;
+        }
     }
 
     /**
      * Releases any resources this ConditionalTagSupport may have (or inherit).
      */
+    @Override
     public void release() {
         super.release();
         init();
     }
 
-    //*********************************************************************
+    // *********************************************************************
     // Private state
 
-    private boolean result;             // the saved result of condition()
-    private String var;			// scoped attribute name
-    private int scope;			// scoped attribute scope
+    private boolean result; // the saved result of condition()
+    private String var; // scoped attribute name
+    private int scope; // scoped attribute scope
 
-
-    //*********************************************************************
+    // *********************************************************************
     // Accessors
 
     /**
      * Sets the 'var' attribute.
      *
-     * @param var Name of the exported scoped variable storing the result of
-     * <tt>condition()</tt>.
+     * @param var Name of the exported scoped variable storing the result of <tt>condition()</tt>.
      */
     public void setVar(String var) {
-	this.var = var;
+        this.var = var;
     }
 
     /**
@@ -129,31 +123,32 @@ public abstract class ConditionalTagSupport
      * @param scope Scope of the 'var' attribute
      */
     public void setScope(String scope) {
-	if (scope.equalsIgnoreCase("page"))
-	    this.scope = PageContext.PAGE_SCOPE;
-	else if (scope.equalsIgnoreCase("request"))
-	    this.scope = PageContext.REQUEST_SCOPE;
-	else if (scope.equalsIgnoreCase("session"))
-	    this.scope = PageContext.SESSION_SCOPE;
-	else if (scope.equalsIgnoreCase("application"))
-	    this.scope = PageContext.APPLICATION_SCOPE;
-	// TODO: Add error handling?  Needs direction from spec.
+        if (scope.equalsIgnoreCase("page")) {
+            this.scope = PageContext.PAGE_SCOPE;
+        } else if (scope.equalsIgnoreCase("request")) {
+            this.scope = PageContext.REQUEST_SCOPE;
+        } else if (scope.equalsIgnoreCase("session")) {
+            this.scope = PageContext.SESSION_SCOPE;
+        } else if (scope.equalsIgnoreCase("application")) {
+            this.scope = PageContext.APPLICATION_SCOPE;
+            // TODO: Add error handling? Needs direction from spec.
+        }
     }
 
-
-    //*********************************************************************
+    // *********************************************************************
     // Utility methods
 
     // expose attributes if we have a non-null 'var'
     private void exposeVariables() {
-        if (var != null)
+        if (var != null) {
             pageContext.setAttribute(var, Boolean.valueOf(result), scope);
+        }
     }
 
     // initializes internal state
     private void init() {
-        result = false;                 // not really necessary
-	var = null;
-	scope = PageContext.PAGE_SCOPE;
+        result = false; // not really necessary
+        var = null;
+        scope = PageContext.PAGE_SCOPE;
     }
 }

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/Config.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/Config.java
@@ -30,31 +30,26 @@ public class Config {
     /*
      * I18N/Formatting actions related configuration data
      */
-    
+
     /**
-     * Name of configuration setting for application- (as opposed to browser-)
-     * based preferred locale
+     * Name of configuration setting for application- (as opposed to browser-) based preferred locale
      */
-    public static final String FMT_LOCALE
-	= "jakarta.servlet.jsp.jstl.fmt.locale";
+    public static final String FMT_LOCALE = "jakarta.servlet.jsp.jstl.fmt.locale";
 
     /**
      * Name of configuration setting for fallback locale
      */
-    public static final String FMT_FALLBACK_LOCALE
-	= "jakarta.servlet.jsp.jstl.fmt.fallbackLocale";
+    public static final String FMT_FALLBACK_LOCALE = "jakarta.servlet.jsp.jstl.fmt.fallbackLocale";
 
     /**
      * Name of configuration setting for i18n localization context
      */
-    public static final String FMT_LOCALIZATION_CONTEXT
-	= "jakarta.servlet.jsp.jstl.fmt.localizationContext";
+    public static final String FMT_LOCALIZATION_CONTEXT = "jakarta.servlet.jsp.jstl.fmt.localizationContext";
 
     /**
      * Name of localization setting for time zone
      */
-    public static final String FMT_TIME_ZONE
-	= "jakarta.servlet.jsp.jstl.fmt.timeZone";
+    public static final String FMT_TIME_ZONE = "jakarta.servlet.jsp.jstl.fmt.timeZone";
 
     /*
      * SQL actions related configuration data
@@ -63,16 +58,13 @@ public class Config {
     /**
      * Name of configuration setting for SQL data source
      */
-    public static final String SQL_DATA_SOURCE
-	= "jakarta.servlet.jsp.jstl.sql.dataSource";
+    public static final String SQL_DATA_SOURCE = "jakarta.servlet.jsp.jstl.sql.dataSource";
 
     /**
-     * Name of configuration setting for maximum number of rows to be included
-     * in SQL query result
+     * Name of configuration setting for maximum number of rows to be included in SQL query result
      */
-    public static final String SQL_MAX_ROWS
-	= "jakarta.servlet.jsp.jstl.sql.maxRows";
-	
+    public static final String SQL_MAX_ROWS = "jakarta.servlet.jsp.jstl.sql.maxRows";
+
     /*
      * Private constants
      */
@@ -84,73 +76,68 @@ public class Config {
     /**
      * Looks up a configuration variable in the given scope.
      *
-     * <p> The lookup of configuration variables is performed as if each scope
-     * had its own name space, that is, the same configuration variable name
-     * in one scope does not replace one stored in a different scope.
+     * <p>
+     * The lookup of configuration variables is performed as if each scope had its own name space, that is, the same
+     * configuration variable name in one scope does not replace one stored in a different scope.
      *
-     * @param pc Page context in which the configuration variable is to be
-     * looked up
+     * @param pageContext Page context in which the configuration variable is to be looked up
      * @param name Configuration variable name
-     * @param scope Scope in which the configuration variable is to be looked
-     * up
+     * @param scope Scope in which the configuration variable is to be looked up
      *
-     * @return The <tt>java.lang.Object</tt> associated with the configuration
-     * variable, or null if it is not defined.
+     * @return The <tt>java.lang.Object</tt> associated with the configuration variable, or null if it is not defined.
      */
-    public static Object get(PageContext pc, String name, int scope) {
-	switch (scope) {
-	case PageContext.PAGE_SCOPE:
-	    return pc.getAttribute(name + PAGE_SCOPE_SUFFIX, scope);
-	case PageContext.REQUEST_SCOPE:
-	    return pc.getAttribute(name + REQUEST_SCOPE_SUFFIX, scope);
-	case PageContext.SESSION_SCOPE:
-	    return get(pc.getSession(), name);
-	case PageContext.APPLICATION_SCOPE:
-	    return pc.getAttribute(name + APPLICATION_SCOPE_SUFFIX, scope);
-	default:
-	    throw new IllegalArgumentException("unknown scope");
-	}
+    public static Object get(PageContext pageContext, String name, int scope) {
+        switch (scope) {
+        case PageContext.PAGE_SCOPE:
+            return pageContext.getAttribute(name + PAGE_SCOPE_SUFFIX, scope);
+        case PageContext.REQUEST_SCOPE:
+            return pageContext.getAttribute(name + REQUEST_SCOPE_SUFFIX, scope);
+        case PageContext.SESSION_SCOPE:
+            return get(pageContext.getSession(), name);
+        case PageContext.APPLICATION_SCOPE:
+            return pageContext.getAttribute(name + APPLICATION_SCOPE_SUFFIX, scope);
+        default:
+            throw new IllegalArgumentException("unknown scope");
+        }
     }
 
     /**
      * Looks up a configuration variable in the "request" scope.
      *
-     * <p> The lookup of configuration variables is performed as if each scope
-     * had its own name space, that is, the same configuration variable name
-     * in one scope does not replace one stored in a different scope.
+     * <p>
+     * The lookup of configuration variables is performed as if each scope had its own name space, that is, the same
+     * configuration variable name in one scope does not replace one stored in a different scope.
      *
-     * @param request Request object in which the configuration variable is to
-     * be looked up
+     * @param request Request object in which the configuration variable is to be looked up
      * @param name Configuration variable name
      *
-     * @return The <tt>java.lang.Object</tt> associated with the configuration
-     * variable, or null if it is not defined.
+     * @return The <tt>java.lang.Object</tt> associated with the configuration variable, or null if it is not defined.
      */
     public static Object get(ServletRequest request, String name) {
-	return request.getAttribute(name + REQUEST_SCOPE_SUFFIX);
+        return request.getAttribute(name + REQUEST_SCOPE_SUFFIX);
     }
 
     /**
      * Looks up a configuration variable in the "session" scope.
      *
-     * <p> The lookup of configuration variables is performed as if each scope
-     * had its own name space, that is, the same configuration variable name
-     * in one scope does not replace one stored in a different scope.</p>
+     * <p>
+     * The lookup of configuration variables is performed as if each scope had its own name space, that is, the same
+     * configuration variable name in one scope does not replace one stored in a different scope.
+     * </p>
      *
-     * @param session Session object in which the configuration variable is to
-     * be looked up
+     * @param session Session object in which the configuration variable is to be looked up
      * @param name Configuration variable name
      *
-     * @return The <tt>java.lang.Object</tt> associated with the configuration
-     * variable, or null if it is not defined, if session is null, or if the session
-     * is invalidated. 
+     * @return The <tt>java.lang.Object</tt> associated with the configuration variable, or null if it is not defined, if
+     * session is null, or if the session is invalidated.
      */
     public static Object get(HttpSession session, String name) {
         Object ret = null;
         if (session != null) {
             try {
                 ret = session.getAttribute(name + SESSION_SCOPE_SUFFIX);
-            } catch (IllegalStateException ex) {} // when session is invalidated
+            } catch (IllegalStateException ex) {
+            } // when session is invalidated
         }
         return ret;
     }
@@ -158,218 +145,200 @@ public class Config {
     /**
      * Looks up a configuration variable in the "application" scope.
      *
-     * <p> The lookup of configuration variables is performed as if each scope
-     * had its own name space, that is, the same configuration variable name
-     * in one scope does not replace one stored in a different scope.
+     * <p>
+     * The lookup of configuration variables is performed as if each scope had its own name space, that is, the same
+     * configuration variable name in one scope does not replace one stored in a different scope.
      *
-     * @param context Servlet context in which the configuration variable is
-     * to be looked up
+     * @param context Servlet context in which the configuration variable is to be looked up
      * @param name Configuration variable name
      *
-     * @return The <tt>java.lang.Object</tt> associated with the configuration
-     * variable, or null if it is not defined.
+     * @return The <tt>java.lang.Object</tt> associated with the configuration variable, or null if it is not defined.
      */
     public static Object get(ServletContext context, String name) {
-	return context.getAttribute(name + APPLICATION_SCOPE_SUFFIX);
+        return context.getAttribute(name + APPLICATION_SCOPE_SUFFIX);
     }
 
     /**
      * Sets the value of a configuration variable in the given scope.
      *
-     * <p> Setting the value of a configuration variable is performed as if
-     * each scope had its own namespace, that is, the same configuration
-     * variable name in one scope does not replace one stored in a different
-     * scope.
+     * <p>
+     * Setting the value of a configuration variable is performed as if each scope had its own namespace, that is, the same
+     * configuration variable name in one scope does not replace one stored in a different scope.
      *
-     * @param pc Page context in which the configuration variable is to be set
+     * @param pageContext Page context in which the configuration variable is to be set
      * @param name Configuration variable name
      * @param value Configuration variable value
      * @param scope Scope in which the configuration variable is to be set
      */
-    public static void set(PageContext pc, String name, Object value,
-			   int scope) {
-	switch (scope) {
-	case PageContext.PAGE_SCOPE:
-	    pc.setAttribute(name + PAGE_SCOPE_SUFFIX, value, scope);
-	    break;
-	case PageContext.REQUEST_SCOPE:
-	    pc.setAttribute(name + REQUEST_SCOPE_SUFFIX, value, scope);
-	    break;
-	case PageContext.SESSION_SCOPE:
-	    pc.setAttribute(name + SESSION_SCOPE_SUFFIX, value, scope);
-	    break;
-	case PageContext.APPLICATION_SCOPE:
-	    pc.setAttribute(name + APPLICATION_SCOPE_SUFFIX, value, scope);
-	    break;
-	default:
-	    throw new IllegalArgumentException("unknown scope");
-	}
+    public static void set(PageContext pageContext, String name, Object value, int scope) {
+        switch (scope) {
+        case PageContext.PAGE_SCOPE:
+            pageContext.setAttribute(name + PAGE_SCOPE_SUFFIX, value, scope);
+            break;
+        case PageContext.REQUEST_SCOPE:
+            pageContext.setAttribute(name + REQUEST_SCOPE_SUFFIX, value, scope);
+            break;
+        case PageContext.SESSION_SCOPE:
+            pageContext.setAttribute(name + SESSION_SCOPE_SUFFIX, value, scope);
+            break;
+        case PageContext.APPLICATION_SCOPE:
+            pageContext.setAttribute(name + APPLICATION_SCOPE_SUFFIX, value, scope);
+            break;
+        default:
+            throw new IllegalArgumentException("unknown scope");
+        }
     }
 
     /**
      * Sets the value of a configuration variable in the "request" scope.
      *
-     * <p> Setting the value of a configuration variable is performed as if
-     * each scope had its own namespace, that is, the same configuration
-     * variable name in one scope does not replace one stored in a different
-     * scope.
+     * <p>
+     * Setting the value of a configuration variable is performed as if each scope had its own namespace, that is, the same
+     * configuration variable name in one scope does not replace one stored in a different scope.
      *
-     * @param request Request object in which the configuration variable is to
-     * be set
+     * @param request Request object in which the configuration variable is to be set
      * @param name Configuration variable name
      * @param value Configuration variable value
      */
     public static void set(ServletRequest request, String name, Object value) {
-	request.setAttribute(name + REQUEST_SCOPE_SUFFIX, value);
+        request.setAttribute(name + REQUEST_SCOPE_SUFFIX, value);
     }
 
     /**
      * Sets the value of a configuration variable in the "session" scope.
      *
-     * <p> Setting the value of a configuration variable is performed as if
-     * each scope had its own namespace, that is, the same configuration
-     * variable name in one scope does not replace one stored in a different
-     * scope.
+     * <p>
+     * Setting the value of a configuration variable is performed as if each scope had its own namespace, that is, the same
+     * configuration variable name in one scope does not replace one stored in a different scope.
      *
-     * @param session Session object in which the configuration variable is to
-     * be set
+     * @param session Session object in which the configuration variable is to be set
      * @param name Configuration variable name
      * @param value Configuration variable value
      */
     public static void set(HttpSession session, String name, Object value) {
-	session.setAttribute(name + SESSION_SCOPE_SUFFIX, value);
+        session.setAttribute(name + SESSION_SCOPE_SUFFIX, value);
     }
 
     /**
      * Sets the value of a configuration variable in the "application" scope.
      *
-     * <p> Setting the value of a configuration variable is performed as if
-     * each scope had its own namespace, that is, the same configuration
-     * variable name in one scope does not replace one stored in a different
-     * scope.
+     * <p>
+     * Setting the value of a configuration variable is performed as if each scope had its own namespace, that is, the same
+     * configuration variable name in one scope does not replace one stored in a different scope.
      *
-     * @param context Servlet context in which the configuration variable is to
-     * be set
+     * @param context Servlet context in which the configuration variable is to be set
      * @param name Configuration variable name
      * @param value Configuration variable value
      */
     public static void set(ServletContext context, String name, Object value) {
-	context.setAttribute(name + APPLICATION_SCOPE_SUFFIX, value);
+        context.setAttribute(name + APPLICATION_SCOPE_SUFFIX, value);
     }
- 
+
     /**
      * Removes a configuration variable from the given scope.
      *
-     * <p> Removing a configuration variable is performed as if each scope had
-     * its own namespace, that is, the same configuration variable name in one
-     * scope does not impact one stored in a different scope.
+     * <p>
+     * Removing a configuration variable is performed as if each scope had its own namespace, that is, the same
+     * configuration variable name in one scope does not impact one stored in a different scope.
      *
-     * @param pc Page context from which the configuration variable is to be
-     * removed
+     * @param pageContext Page context from which the configuration variable is to be removed
      * @param name Configuration variable name
-     * @param scope Scope from which the configuration variable is to be 
-     * removed
+     * @param scope Scope from which the configuration variable is to be removed
      */
-    public static void remove(PageContext pc, String name, int scope) {
-	switch (scope) {
-	case PageContext.PAGE_SCOPE:
-	    pc.removeAttribute(name + PAGE_SCOPE_SUFFIX, scope);
-	    break;
-	case PageContext.REQUEST_SCOPE:
-	    pc.removeAttribute(name + REQUEST_SCOPE_SUFFIX, scope);
-	    break;
-	case PageContext.SESSION_SCOPE:
-	    pc.removeAttribute(name + SESSION_SCOPE_SUFFIX, scope);
-	    break;
-	case PageContext.APPLICATION_SCOPE:
-	    pc.removeAttribute(name + APPLICATION_SCOPE_SUFFIX, scope);
-	    break;
-	default:
-	    throw new IllegalArgumentException("unknown scope");
-	}
+    public static void remove(PageContext pageContext, String name, int scope) {
+        switch (scope) {
+        case PageContext.PAGE_SCOPE:
+            pageContext.removeAttribute(name + PAGE_SCOPE_SUFFIX, scope);
+            break;
+        case PageContext.REQUEST_SCOPE:
+            pageContext.removeAttribute(name + REQUEST_SCOPE_SUFFIX, scope);
+            break;
+        case PageContext.SESSION_SCOPE:
+            pageContext.removeAttribute(name + SESSION_SCOPE_SUFFIX, scope);
+            break;
+        case PageContext.APPLICATION_SCOPE:
+            pageContext.removeAttribute(name + APPLICATION_SCOPE_SUFFIX, scope);
+            break;
+        default:
+            throw new IllegalArgumentException("unknown scope");
+        }
     }
 
     /**
      * Removes a configuration variable from the "request" scope.
      *
-     * <p> Removing a configuration variable is performed as if each scope had
-     * its own namespace, that is, the same configuration variable name in one
-     * scope does not impact one stored in a different scope.
-     * 
-     * @param request Request object from which the configuration variable is
-     * to be removed
+     * <p>
+     * Removing a configuration variable is performed as if each scope had its own namespace, that is, the same
+     * configuration variable name in one scope does not impact one stored in a different scope.
+     *
+     * @param request Request object from which the configuration variable is to be removed
      * @param name Configuration variable name
      */
     public static void remove(ServletRequest request, String name) {
-	request.removeAttribute(name + REQUEST_SCOPE_SUFFIX);
+        request.removeAttribute(name + REQUEST_SCOPE_SUFFIX);
     }
 
     /**
      * Removes a configuration variable from the "session" scope.
      *
-     * <p> Removing a configuration variable is performed as if each scope had
-     * its own namespace, that is, the same configuration variable name in one
-     * scope does not impact one stored in a different scope.
+     * <p>
+     * Removing a configuration variable is performed as if each scope had its own namespace, that is, the same
+     * configuration variable name in one scope does not impact one stored in a different scope.
      *
-     * @param session Session object from which the configuration variable is
-     * to be removed
+     * @param session Session object from which the configuration variable is to be removed
      * @param name Configuration variable name
      */
     public static void remove(HttpSession session, String name) {
-	session.removeAttribute(name + SESSION_SCOPE_SUFFIX);
+        session.removeAttribute(name + SESSION_SCOPE_SUFFIX);
     }
 
     /**
      * Removes a configuration variable from the "application" scope.
      *
-     * <p> Removing a configuration variable is performed as if each scope had
-     * its own namespace, that is, the same configuration variable name in one
-     * scope does not impact one stored in a different scope.
+     * <p>
+     * Removing a configuration variable is performed as if each scope had its own namespace, that is, the same
+     * configuration variable name in one scope does not impact one stored in a different scope.
      *
-     * @param context Servlet context from which the configuration variable is
-     * to be removed
+     * @param context Servlet context from which the configuration variable is to be removed
      * @param name Configuration variable name
      */
     public static void remove(ServletContext context, String name) {
-	context.removeAttribute(name + APPLICATION_SCOPE_SUFFIX);
+        context.removeAttribute(name + APPLICATION_SCOPE_SUFFIX);
     }
- 
-    /**
-     * Finds the value associated with a specific configuration setting
-     * identified by its context initialization parameter name.
-     *
-     * <p> For each of the JSP scopes (page, request, session, application),
-     * get the value of the configuration variable identified by <tt>name</tt>
-     * using method <tt>get()</tt>. Return as soon as a non-null value is
-     * found. If no value is found, get the value of the context initialization
-     * parameter identified by <tt>name</tt>.
-     *
-     * @param pc Page context in which the configuration setting is to be 
-     * searched
-     * @param name Context initialization parameter name of the configuration
-     * setting
-     * 
-     * @return The <tt>java.lang.Object</tt> associated with the configuration
-     * setting identified by <tt>name</tt>, or null if it is not defined.
-     */
-    public static Object find(PageContext pc, String name) {
-	Object ret = get(pc, name, PageContext.PAGE_SCOPE);
-	if (ret == null) {
-	    ret = get(pc, name, PageContext.REQUEST_SCOPE);
-	    if (ret == null) {
-		if (pc.getSession() != null) {
-		    // check session only if a session is present
-		    ret = get(pc, name, PageContext.SESSION_SCOPE);
-		}
-		if (ret == null) {
-		    ret = get(pc, name, PageContext.APPLICATION_SCOPE);
-		    if (ret == null) {
-			ret = pc.getServletContext().getInitParameter(name);
-		    }
-		}
-	    }
-	}
 
-	return ret;
+    /**
+     * Finds the value associated with a specific configuration setting identified by its context initialization parameter
+     * name.
+     *
+     * <p>
+     * For each of the JSP scopes (page, request, session, application), get the value of the configuration variable
+     * identified by <tt>name</tt> using method <tt>get()</tt>. Return as soon as a non-null value is found. If no value is
+     * found, get the value of the context initialization parameter identified by <tt>name</tt>.
+     *
+     * @param pageContext Page context in which the configuration setting is to be searched
+     * @param name Context initialization parameter name of the configuration setting
+     *
+     * @return The <tt>java.lang.Object</tt> associated with the configuration setting identified by <tt>name</tt>, or null
+     * if it is not defined.
+     */
+    public static Object find(PageContext pageContext, String name) {
+        Object ret = get(pageContext, name, PageContext.PAGE_SCOPE);
+        if (ret == null) {
+            ret = get(pageContext, name, PageContext.REQUEST_SCOPE);
+            if (ret == null) {
+                if (pageContext.getSession() != null) {
+                    // check session only if a session is present
+                    ret = get(pageContext, name, PageContext.SESSION_SCOPE);
+                }
+                if (ret == null) {
+                    ret = get(pageContext, name, PageContext.APPLICATION_SCOPE);
+                    if (ret == null) {
+                        ret = pageContext.getServletContext().getInitParameter(name);
+                    }
+                }
+            }
+        }
+
+        return ret;
     }
 }

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/IndexedValueExpression.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/IndexedValueExpression.java
@@ -26,15 +26,13 @@ import jakarta.el.ValueExpression;
  */
 public final class IndexedValueExpression extends ValueExpression {
 
-    /**
-     * 
-     */
     private static final long serialVersionUID = 1L;
+
     protected final Integer i;
     protected final ValueExpression orig;
 
     /**
-     * 
+     *
      */
     public IndexedValueExpression(ValueExpression orig, int i) {
         this.i = Integer.valueOf(i);
@@ -43,9 +41,10 @@ public final class IndexedValueExpression extends ValueExpression {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see jakarta.el.ValueExpression#getValue(jakarta.el.ELContext)
      */
+    @Override
     public Object getValue(ELContext context) {
         Object base = this.orig.getValue(context);
         if (base != null) {
@@ -57,10 +56,10 @@ public final class IndexedValueExpression extends ValueExpression {
 
     /*
      * (non-Javadoc)
-     * 
-     * @see jakarta.el.ValueExpression#setValue(jakarta.el.ELContext,
-     *      java.lang.Object)
+     *
+     * @see jakarta.el.ValueExpression#setValue(jakarta.el.ELContext, java.lang.Object)
      */
+    @Override
     public void setValue(ELContext context, Object value) {
         Object base = this.orig.getValue(context);
         if (base != null) {
@@ -71,9 +70,10 @@ public final class IndexedValueExpression extends ValueExpression {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see jakarta.el.ValueExpression#isReadOnly(jakarta.el.ELContext)
      */
+    @Override
     public boolean isReadOnly(ELContext context) {
         Object base = this.orig.getValue(context);
         if (base != null) {
@@ -85,9 +85,10 @@ public final class IndexedValueExpression extends ValueExpression {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see jakarta.el.ValueExpression#getType(jakarta.el.ELContext)
      */
+    @Override
     public Class getType(ELContext context) {
         Object base = this.orig.getValue(context);
         if (base != null) {
@@ -99,48 +100,52 @@ public final class IndexedValueExpression extends ValueExpression {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see jakarta.el.ValueExpression#getExpectedType()
      */
+    @Override
     public Class getExpectedType() {
         return Object.class;
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see jakarta.el.Expression#getExpressionString()
      */
+    @Override
     public String getExpressionString() {
         return this.orig.getExpressionString();
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see jakarta.el.Expression#equals(java.lang.Object)
      */
+    @Override
     public boolean equals(Object obj) {
         return this.orig.equals(obj);
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see jakarta.el.Expression#hashCode()
      */
+    @Override
     public int hashCode() {
         return this.orig.hashCode();
     }
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see jakarta.el.Expression#isLiteralText()
      */
+    @Override
     public boolean isLiteralText() {
         return false;
     }
 
 }
-

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/IteratedExpression.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/IteratedExpression.java
@@ -17,10 +17,9 @@
 
 package jakarta.servlet.jsp.jstl.core;
 
-import java.io.Serializable;
-import java.util.Iterator;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.StringTokenizer;
 
@@ -28,13 +27,11 @@ import jakarta.el.ELContext;
 import jakarta.el.ELException;
 import jakarta.el.ValueExpression;
 
-import jakarta.servlet.jsp.JspTagException;
-
 /**
  * @author Kin-man Chung
  * @version $Id: IteratedExpression.java,v 1.6 2006/11/17 19:48:41 jluehe Exp $
  */
-public final class IteratedExpression /*implements Serializable*/ {
+public final class IteratedExpression /* implements Serializable */ {
 
     private static final long serialVersionUID = 1L;
     protected final ValueExpression orig;
@@ -51,6 +48,7 @@ public final class IteratedExpression /*implements Serializable*/ {
 
     /**
      * Evaluates the stored ValueExpression and return the indexed item.
+     *
      * @param context The ELContext used to evaluate the ValueExpression
      * @param i The index of the item to be retrieved
      */
@@ -86,22 +84,17 @@ public final class IteratedExpression /*implements Serializable*/ {
 
         Iterator iter;
         if (obj instanceof String) {
-            iter = toIterator(new StringTokenizer((String)obj, delims));
-        }
-        else if (obj instanceof Iterator) {
-            iter = (Iterator)obj;
-        }
-        else if (obj instanceof Collection) {
+            iter = toIterator(new StringTokenizer((String) obj, delims));
+        } else if (obj instanceof Iterator) {
+            iter = (Iterator) obj;
+        } else if (obj instanceof Collection) {
             iter = toIterator(((Collection) obj).iterator());
-        }
-        else if (obj instanceof Enumeration) {
-            iter = toIterator((Enumeration)obj);
-        }
-        else if (obj instanceof Map) {
-            iter = ((Map)obj).entrySet().iterator();
+        } else if (obj instanceof Enumeration) {
+            iter = toIterator((Enumeration) obj);
+        } else if (obj instanceof Map) {
+            iter = ((Map) obj).entrySet().iterator();
         } else {
-            throw new ELException("Don't know how to iterate over supplied "
-                                  + "items in forEach");
+            throw new ELException("Don't know how to iterate over supplied " + "items in forEach");
         }
         return iter;
     }
@@ -111,11 +104,13 @@ public final class IteratedExpression /*implements Serializable*/ {
             public boolean hasNext() {
                 return obj.hasMoreElements();
             }
+
             public Object next() {
                 return obj.nextElement();
             }
-            public void remove() {}
+
+            public void remove() {
+            }
         };
     }
 }
-

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/IteratedValueExpression.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/IteratedValueExpression.java
@@ -70,4 +70,3 @@ public final class IteratedValueExpression extends ValueExpression {
         return false;
     }
 }
-

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTag.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTag.java
@@ -20,36 +20,34 @@ package jakarta.servlet.jsp.jstl.core;
 import jakarta.servlet.jsp.tagext.Tag;
 
 /**
- * <p>The Jakarta Standard Tag Library allows developers to write custom iteration tags by
- * implementing the LoopTag interface.  This is not to be confused
- * with <tt>jakarta.servlet.jsp.tagext.IterationTag</tt> as defined in Jakarta Server Pages 1.2.
- * LoopTag establishes a mechanism for iteration tags to be recognized
- * and for type-safe implicit collaboration with custom subtags.
- * 
- * <p>In most cases, it will not be necessary to implement this interface
- * manually, for a base support class (<tt>LoopTagSupport</tt>) is provided
- * to facilitate implementation.</p>
+ * <p>
+ * The Jakarta Standard Tag Library allows developers to write custom iteration tags by implementing the LoopTag
+ * interface. This is not to be confused with <tt>jakarta.servlet.jsp.tagext.IterationTag</tt> as defined in Jakarta
+ * Server Pages 1.2. LoopTag establishes a mechanism for iteration tags to be recognized and for type-safe implicit
+ * collaboration with custom subtags.
+ *
+ * <p>
+ * In most cases, it will not be necessary to implement this interface manually, for a base support class
+ * (<tt>LoopTagSupport</tt>) is provided to facilitate implementation.
+ * </p>
  *
  * @author Shawn Bayern
  */
-
 public interface LoopTag extends Tag {
 
     /**
-     * Retrieves the current item in the iteration.  Behaves
-     * idempotently; calling getCurrent() repeatedly should return the same
-     * Object until the iteration is advanced.  (Specifically, calling
-     * getCurrent() does <b>not</b> advance the iteration.)
+     * Retrieves the current item in the iteration. Behaves idempotently; calling getCurrent() repeatedly should return the
+     * same Object until the iteration is advanced. (Specifically, calling getCurrent() does <b>not</b> advance the
+     * iteration.)
      *
      * @return the current item as an object
      */
-    public Object getCurrent();
+    Object getCurrent();
 
     /**
-     * Retrieves a 'status' object to provide information about the
-     * current round of the iteration.
+     * Retrieves a 'status' object to provide information about the current round of the iteration.
      *
      * @return The LoopTagStatus for the current <tt>LoopTag</tt>.
      */
-    public LoopTagStatus getLoopStatus();
+    LoopTagStatus getLoopStatus();
 }

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTagStatus.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTagStatus.java
@@ -18,106 +18,90 @@
 package jakarta.servlet.jsp.jstl.core;
 
 /**
- * <p>Exposes the current status of
- * an iteration.  The Jakarta Standard Tag Library provides a mechanism for LoopTags to
- * return information about the current index of the iteration and
- * convenience methods to determine whether or not the current round is
- * either the first or last in the iteration.  It also lets authors
- * use the status object to obtain information about the iteration range,
- * step, and current object.</p>
+ * <p>
+ * Exposes the current status of an iteration. The Jakarta Standard Tag Library provides a mechanism for LoopTags to
+ * return information about the current index of the iteration and convenience methods to determine whether or not the
+ * current round is either the first or last in the iteration. It also lets authors use the status object to obtain
+ * information about the iteration range, step, and current object.
+ * </p>
  *
- * <p>Environments that require more status can extend this interface.</p>
+ * <p>
+ * Environments that require more status can extend this interface.
+ * </p>
  *
  * @author Shawn Bayern
  */
-
 public interface LoopTagStatus {
 
     /**
-     * Retrieves the current item in the iteration.  Behaves
-     * idempotently; calling getCurrent() repeatedly should return the same
-     * Object until the iteration is advanced.  (Specifically, calling
-     * getCurrent() does <b>not</b> advance the iteration.)
+     * Retrieves the current item in the iteration. Behaves idempotently; calling getCurrent() repeatedly should return the
+     * same Object until the iteration is advanced. (Specifically, calling getCurrent() does <b>not</b> advance the
+     * iteration.)
      *
      * @return the current item as an object
      */
-    public Object getCurrent();
+    Object getCurrent();
 
     /**
-     * Retrieves the index of the current round of the iteration.  If
-     * iteration is being performed over a subset of an underlying
-     * array, java.lang.Collection, or other type, the index returned
-     * is absolute with respect to the underlying collection.  Indices
-     * are 0-based.
+     * Retrieves the index of the current round of the iteration. If iteration is being performed over a subset of an
+     * underlying array, java.lang.Collection, or other type, the index returned is absolute with respect to the underlying
+     * collection. Indices are 0-based.
      *
      * @return the 0-based index of the current round of the iteration
      */
-    public int getIndex();
+    int getIndex();
 
     /**
-     * <p>Retrieves the "count" of the current round of the iteration.  The
-     * count is a relative, 1-based sequence number identifying the
-     * current "round" of iteration (in context with all rounds the
-     * current iteration will perform).</p>
+     * <p>
+     * Retrieves the "count" of the current round of the iteration. The count is a relative, 1-based sequence number
+     * identifying the current "round" of iteration (in context with all rounds the current iteration will perform).
+     * </p>
      *
-     * <p>As an example, an iteration with begin = 5, end = 15, and step =
-     * 5 produces the counts 1, 2, and 3 in that order.</p>
+     * <p>
+     * As an example, an iteration with begin = 5, end = 15, and step = 5 produces the counts 1, 2, and 3 in that order.
+     * </p>
      *
      * @return the 1-based count of the current round of the iteration
      */
-    public int getCount();
+    int getCount();
 
     /**
-     * Returns information about whether the current round of the
-     * iteration is the first one.  This current round may be the 'first'
-     * even when getIndex() != 0, for 'index' refers to the absolute
-     * index of the current 'item' in the context of its underlying
-     * collection.  It is always that case that a true result from
-     * isFirst() implies getCount() == 1.
-     * 
-     * @return <tt>true</tt> if the current round is the first in the
-     * iteration, <tt>false</tt> otherwise.
-     */
-    public boolean isFirst();
-
-    /**
-     * Returns information about whether the current round of the
-     * iteration is the last one.  As with isFirst(), subsetting is
-     * taken into account.  isLast() doesn't necessarily refer to the
-     * status of the underlying Iterator; it refers to whether or not
-     * the current round will be the final round of iteration for the
-     * tag associated with this LoopTagStatus.
-     * 
-     * @return <tt>true</tt> if the current round is the last in the
-     * iteration, <tt>false</tt> otherwise.
-     */
-    public boolean isLast();
-
-    /**
-     * Returns the value of the 'begin' attribute for the associated tag,
-     * or null if no 'begin' attribute was specified.
+     * Returns information about whether the current round of the iteration is the first one. This current round may be the
+     * 'first' even when getIndex() != 0, for 'index' refers to the absolute index of the current 'item' in the context of
+     * its underlying collection. It is always that case that a true result from isFirst() implies getCount() == 1.
      *
-     * @return the 'begin' value for the associated tag, or null
-     * if no 'begin' attribute was specified
+     * @return <tt>true</tt> if the current round is the first in the iteration, <tt>false</tt> otherwise.
      */
-    public Integer getBegin();
+    boolean isFirst();
 
     /**
-     * Returns the value of the 'end' attribute for the associated tag,
-     * or null if no 'end' attribute was specified.
+     * Returns information about whether the current round of the iteration is the last one. As with isFirst(), subsetting
+     * is taken into account. isLast() doesn't necessarily refer to the status of the underlying Iterator; it refers to
+     * whether or not the current round will be the final round of iteration for the tag associated with this LoopTagStatus.
      *
-     * @return the 'end' value for the associated tag, or null
-     * if no 'end' attribute was specified
+     * @return <tt>true</tt> if the current round is the last in the iteration, <tt>false</tt> otherwise.
      */
-    public Integer getEnd();
+    boolean isLast();
 
     /**
-     * Returns the value of the 'step' attribute for the associated tag,
-     * or null if no 'step' attribute was specified.
+     * Returns the value of the 'begin' attribute for the associated tag, or null if no 'begin' attribute was specified.
      *
-     * @return the 'step' value for the associated tag, or null
-     * if no 'step' attribute was specified
+     * @return the 'begin' value for the associated tag, or null if no 'begin' attribute was specified
      */
-    public Integer getStep();
+    Integer getBegin();
+
+    /**
+     * Returns the value of the 'end' attribute for the associated tag, or null if no 'end' attribute was specified.
+     *
+     * @return the 'end' value for the associated tag, or null if no 'end' attribute was specified
+     */
+    Integer getEnd();
+
+    /**
+     * Returns the value of the 'step' attribute for the associated tag, or null if no 'step' attribute was specified.
+     *
+     * @return the 'step' value for the associated tag, or null if no 'step' attribute was specified
+     */
+    Integer getStep();
 
 }

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTagSupport.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/core/LoopTagSupport.java
@@ -17,16 +17,15 @@
 
 package jakarta.servlet.jsp.jstl.core;
 
-import java.util.List;
 import java.util.Collection;
 import java.util.Enumeration;
-import java.util.Map;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
+import jakarta.el.ELException;
 import jakarta.el.ValueExpression;
 import jakarta.el.VariableMapper;
-import jakarta.el.ELException;
-
 import jakarta.servlet.jsp.JspException;
 import jakarta.servlet.jsp.JspTagException;
 import jakarta.servlet.jsp.PageContext;
@@ -35,68 +34,59 @@ import jakarta.servlet.jsp.tagext.TagSupport;
 import jakarta.servlet.jsp.tagext.TryCatchFinally;
 
 /**
- * <p>Base support class to facilitate implementation of iteration tags.</p>
+ * <p>
+ * Base support class to facilitate implementation of iteration tags.
+ * </p>
  *
- * <p>Since most iteration tags will behave identically with respect to
- * actual iterative behavior, the Jakarta Standard Tag Library provides this
- * base support class to facilitate implementation.  Many iteration tags
- * will extend this and merely implement the <tt>hasNext()</tt> and 
- * <tt>next()</tt> methods
- * to provide contents for the handler to iterate over.</p>
+ * <p>
+ * Since most iteration tags will behave identically with respect to actual iterative behavior, the Jakarta Standard Tag
+ * Library provides this base support class to facilitate implementation. Many iteration tags will extend this and
+ * merely implement the <tt>hasNext()</tt> and <tt>next()</tt> methods to provide contents for the handler to iterate
+ * over.
+ * </p>
  *
- * <p>In particular, this base class provides support for:</p>
- * 
+ * <p>
+ * In particular, this base class provides support for:
+ * </p>
+ *
  * <ul>
- *  <li> Iteration control, based on protected <tt>prepare()</tt>, <tt>next()</tt>,
- *       and <tt>hasNext()</tt> methods
- *  <li> Subsetting (<tt>begin</tt>, <tt>end</tt>, <tt>step</tt> functionality, 
- *       including validation
- *       of subset parameters for sensibility)
- *  <li> item retrieval (<tt>getCurrent()</tt>)
- *  <li> status retrieval (<tt>LoopTagStatus</tt>)
- *  <li> exposing attributes (set by <tt>var</tt> and <tt>varStatus</tt> attributes)
+ * <li>Iteration control, based on protected <tt>prepare()</tt>, <tt>next()</tt>, and <tt>hasNext()</tt> methods
+ * <li>Subsetting (<tt>begin</tt>, <tt>end</tt>, <tt>step</tt> functionality, including validation of subset parameters
+ * for sensibility)
+ * <li>item retrieval (<tt>getCurrent()</tt>)
+ * <li>status retrieval (<tt>LoopTagStatus</tt>)
+ * <li>exposing attributes (set by <tt>var</tt> and <tt>varStatus</tt> attributes)
  * </ul>
  *
- * <p>In providing support for these tasks, <tt>LoopTagSupport</tt> contains
- * certain control variables that act to modify the iteration.  Accessors
- * are provided for these control variables when the variables represent
- * information needed or wanted at translation time (e.g., <tt>var</tt>, 
- * <tt>varStatus</tt>).  For
- * other variables, accessors cannot be provided here since subclasses
- * may differ on their implementations of how those accessors are received.
- * For instance, one subclass might accept a <tt>String</tt> and convert it into
- * an object of a specific type by using an expression evaluator; others
- * might accept objects directly.  Still others might not want to expose
- * such information to outside control.</p>
+ * <p>
+ * In providing support for these tasks, <tt>LoopTagSupport</tt> contains certain control variables that act to modify
+ * the iteration. Accessors are provided for these control variables when the variables represent information needed or
+ * wanted at translation time (e.g., <tt>var</tt>, <tt>varStatus</tt>). For other variables, accessors cannot be
+ * provided here since subclasses may differ on their implementations of how those accessors are received. For instance,
+ * one subclass might accept a <tt>String</tt> and convert it into an object of a specific type by using an expression
+ * evaluator; others might accept objects directly. Still others might not want to expose such information to outside
+ * control.
+ * </p>
  *
  * @author Shawn Bayern
  */
-
-public abstract class LoopTagSupport
-    extends TagSupport
-    implements LoopTag, IterationTag, TryCatchFinally
-{
-    //*********************************************************************
-    // 'Protected' state 
+public abstract class LoopTagSupport extends TagSupport implements LoopTag, IterationTag, TryCatchFinally {
+    // *********************************************************************
+    // 'Protected' state
 
     /*
-     * JavaBean-style properties and other state slaved to them.  These
-     * properties can be set directly by accessors; they will not be
-     * modified by the LoopTagSupport implementation -- and should
-     * not be modified by subclasses outside accessors unless those
-     * subclasses are perfectly aware of what they're doing.
-     * (An example where such non-accessor modification might be sensible
-     * is in the doStartTag() method of an EL-aware subclass.)
+     * JavaBean-style properties and other state slaved to them. These properties can be set directly by accessors; they
+     * will not be modified by the LoopTagSupport implementation -- and should not be modified by subclasses outside
+     * accessors unless those subclasses are perfectly aware of what they're doing. (An example where such non-accessor
+     * modification might be sensible is in the doStartTag() method of an EL-aware subclass.)
      */
 
     /** Starting index ('begin' attribute) */
     protected int begin;
 
     /**
-     * Ending index of the iteration ('end' attribute).
-     * A value of -1 internally indicates 'no end
-     * specified', although accessors for the core Jakarta Standard Tag Library tags do not
-     * allow this value to be supplied directly by the user.
+     * Ending index of the iteration ('end' attribute). A value of -1 internally indicates 'no end specified', although
+     * accessors for the core Jakarta Standard Tag Library tags do not allow this value to be supplied directly by the user.
      */
     protected int end;
 
@@ -118,113 +108,102 @@ public abstract class LoopTagSupport
     /** The deferred expression if any */
     protected ValueExpression deferredExpression;
 
-    /** A temporary used to hold the previous value (from the enclosing
-        iteration tag) for the EL variable.  */
+    /**
+     * A temporary used to hold the previous value (from the enclosing iteration tag) for the EL variable.
+     */
     private ValueExpression oldMappedValue;
 
-
-    //*********************************************************************
+    // *********************************************************************
     // 'Private' state (implementation details)
 
     /*
-     * State exclusively internal to the default, reference implementation.
-     * (While this state is kept private to ensure consistency, 'status'
-     * and 'item' happen to have one-for-one, read-only, accesor methods
-     * as part of the LoopTag interface.)
+     * State exclusively internal to the default, reference implementation. (While this state is kept private to ensure
+     * consistency, 'status' and 'item' happen to have one-for-one, read-only, accesor methods as part of the LoopTag
+     * interface.)
      *
-     * 'last' is kept separately for two reasons:  (a) to avoid
-     * running a computation every time it's requested, and (b) to
-     * let LoopTagStatus.isLast() avoid throwing any exceptions,
-     * which would complicate subtag and scripting-variable use.
+     * 'last' is kept separately for two reasons: (a) to avoid running a computation every time it's requested, and (b) to
+     * let LoopTagStatus.isLast() avoid throwing any exceptions, which would complicate subtag and scripting-variable use.
      *
-     * Our 'internal index' begins at 0 and increases by 'step' each
-     * round; this is arbitrary, but it seemed a simple way of keeping
-     * track of the information we need.  To avoid computing
-     * getLoopStatus().getCount() by dividing index / step, we keep
-     * a separate 'count' and increment it by 1 each round (as a minor
-     * performance improvement).
+     * Our 'internal index' begins at 0 and increases by 'step' each round; this is arbitrary, but it seemed a simple way of
+     * keeping track of the information we need. To avoid computing getLoopStatus().getCount() by dividing index / step, we
+     * keep a separate 'count' and increment it by 1 each round (as a minor performance improvement).
      */
-    private LoopTagStatus status;               // our LoopTagStatus
-    private Object item;                        // the current item
-    private int index;                          // the current internal index
-    private int count;                          // the iteration count
-    private boolean last;                       // current round == last one?
+    private LoopTagStatus status; // our LoopTagStatus
+    private Object item; // the current item
+    private int index; // the current internal index
+    private int count; // the iteration count
+    private boolean last; // current round == last one?
     private IteratedExpression iteratedExpression;
-                // holds an instance shared by all ValueExpression created
-                // for variableMapper, for iterators.
+    // holds an instance shared by all ValueExpression created
+    // for variableMapper, for iterators.
 
-    //*********************************************************************
+    // *********************************************************************
     // Constructor
 
     /**
-     * Constructs a new LoopTagSupport.  As with TagSupport, subclasses
-     * should not implement constructors with arguments, and no-arguments
-     * constructors implemented by subclasses must call the superclass
-     * constructor.
+     * Constructs a new LoopTagSupport. As with TagSupport, subclasses should not implement constructors with arguments, and
+     * no-arguments constructors implemented by subclasses must call the superclass constructor.
      */
     public LoopTagSupport() {
         super();
         init();
     }
 
-
-    //*********************************************************************
+    // *********************************************************************
     // Abstract methods
 
     /**
-     * <p>Returns the next object over which the tag should iterate.  This
-     * method must be provided by concrete subclasses of LoopTagSupport
-     * to inform the base logic about what objects it should iterate over.</p>
+     * <p>
+     * Returns the next object over which the tag should iterate. This method must be provided by concrete subclasses of
+     * LoopTagSupport to inform the base logic about what objects it should iterate over.
+     * </p>
      *
-     * <p>It is expected that this method will generally be backed by an
-     * Iterator, but this will not always be the case.  In particular, if
-     * retrieving the next object raises the possibility of an exception
-     * being thrown, this method allows that exception to propagate back
-     * to the JSP container as a JspTagException; a standalone Iterator
-     * would not be able to do this.  (This explains why LoopTagSupport
-     * does not simply call for an Iterator from its subtags.)</p>
-     * 
+     * <p>
+     * It is expected that this method will generally be backed by an Iterator, but this will not always be the case. In
+     * particular, if retrieving the next object raises the possibility of an exception being thrown, this method allows
+     * that exception to propagate back to the JSP container as a JspTagException; a standalone Iterator would not be able
+     * to do this. (This explains why LoopTagSupport does not simply call for an Iterator from its subtags.)
+     * </p>
+     *
      * @return the java.lang.Object to use in the next round of iteration
-     * @exception java.util.NoSuchElementException
-     *            if next() is called but no new elements are available
-     * @exception jakarta.servlet.jsp.JspTagException
-     *            for other, unexpected exceptions
+     * @exception java.util.NoSuchElementException if next() is called but no new elements are available
+     * @exception jakarta.servlet.jsp.JspTagException for other, unexpected exceptions
      */
     protected abstract Object next() throws JspTagException;
 
     /**
-     * <p>Returns information concerning the availability of more items
-     * over which to iterate.  This method must be provided by concrete
-     * subclasses of LoopTagSupport to assist the iterative logic
-     * provided by the supporting base class.</p>
-     *  
-     * <p>See <a href="#next()">next</a> for more information about the
-     * purpose and expectations behind this tag.</p>
+     * <p>
+     * Returns information concerning the availability of more items over which to iterate. This method must be provided by
+     * concrete subclasses of LoopTagSupport to assist the iterative logic provided by the supporting base class.
+     * </p>
      *
-     * @return <tt>true</tt> if there is at least one more item to iterate
-     *         over, <tt>false</tt> otherwise
+     * <p>
+     * See <a href="#next()">next</a> for more information about the purpose and expectations behind this tag.
+     * </p>
+     *
+     * @return <tt>true</tt> if there is at least one more item to iterate over, <tt>false</tt> otherwise
      * @exception jakarta.servlet.jsp.JspTagException
      * @see #next
      */
     protected abstract boolean hasNext() throws JspTagException;
 
     /**
-     * <p>Prepares for a single tag invocation.  Specifically, allows
-     * subclasses to prepare for calls to hasNext() and next(). 
-     * Subclasses can assume that prepare() will be called once for
-     * each invocation of doStartTag() in the superclass.</p>
+     * <p>
+     * Prepares for a single tag invocation. Specifically, allows subclasses to prepare for calls to hasNext() and next().
+     * Subclasses can assume that prepare() will be called once for each invocation of doStartTag() in the superclass.
+     * </p>
      *
      * @exception jakarta.servlet.jsp.JspTagException
      */
     protected abstract void prepare() throws JspTagException;
 
-
-    //*********************************************************************
+    // *********************************************************************
     // Lifecycle management and implementation of iterative behavior
 
     /**
      * Releases any resources this LoopTagSupport may have (or inherit).
      */
+    @Override
     public void release() {
         super.release();
         init();
@@ -233,6 +212,7 @@ public abstract class LoopTagSupport
     /**
      * Begins iterating by processing the first item.
      */
+    @Override
     public int doStartTag() throws JspException {
         if (end != -1 && begin > end) {
             return SKIP_BODY;
@@ -252,15 +232,15 @@ public abstract class LoopTagSupport
         discardIgnoreSubset(begin);
 
         // get the item we're interested in
-        if (hasNext())
+        if (hasNext()) {
             // index is 0-based, so we don't update it for the first item
             item = next();
-        else
+        } else {
             return SKIP_BODY;
+        }
 
         /*
-         * now discard anything we have to "step" over.
-         * (we do this in advance to support LoopTagStatus.isLast())
+         * now discard anything we have to "step" over. (we do this in advance to support LoopTagStatus.isLast())
          */
         discard(step - 1);
 
@@ -271,9 +251,10 @@ public abstract class LoopTagSupport
     }
 
     /**
-     * Continues the iteration when appropriate -- that is, if we (a) have
-     * more items and (b) don't run over our 'end' (given our 'step').
+     * Continues the iteration when appropriate -- that is, if we (a) have more items and (b) don't run over our 'end'
+     * (given our 'step').
      */
+    @Override
     public int doAfterBody() throws JspException {
 
         // re-sync the index, given our prior behind-the-scenes 'step'
@@ -286,12 +267,12 @@ public abstract class LoopTagSupport
         if (hasNext() && !atEnd()) {
             index++;
             item = next();
-        } else
+        } else {
             return SKIP_BODY;
+        }
 
         /*
-         * now discard anything we have to "step" over.
-         * (we do this in advance to support LoopTagStatus.isLast())
+         * now discard anything we have to "step" over. (we do this in advance to support LoopTagStatus.isLast())
          */
         discard(step - 1);
 
@@ -304,139 +285,146 @@ public abstract class LoopTagSupport
     /**
      * Removes any attributes that this LoopTagSupport set.
      *
-     * <p> These attributes are intended to support scripting variables with
-     * NESTED scope, so we don't want to pollute attribute space by leaving
-     * them lying around.
+     * <p>
+     * These attributes are intended to support scripting variables with NESTED scope, so we don't want to pollute attribute
+     * space by leaving them lying around.
      */
+    @Override
     public void doFinally() {
-	/*
-	 * Make sure to un-expose variables, restoring them to their
-	 * prior values, if applicable.
+        /*
+         * Make sure to un-expose variables, restoring them to their prior values, if applicable.
          */
-	unExposeVariables();
+        unExposeVariables();
     }
 
     /**
      * Rethrows the given Throwable.
      */
+    @Override
     public void doCatch(Throwable t) throws Throwable {
-	throw t;
+        throw t;
     }
 
-    //*********************************************************************
+    // *********************************************************************
     // Accessor methods
 
     /*
-     * Overview:  The getXXX() methods we provide implement the Tag
-     * contract.  setXXX() accessors are provided only for those
-     * properties (attributes) that must be known at translation time,
-     * on the premise that these accessors will vary less than the
-     * others in terms of their interface with the page author.
+     * Overview: The getXXX() methods we provide implement the Tag contract. setXXX() accessors are provided only for those
+     * properties (attributes) that must be known at translation time, on the premise that these accessors will vary less
+     * than the others in terms of their interface with the page author.
      */
 
     /*
-     * (Purposely inherit JavaDoc and semantics from LoopTag.
-     * Subclasses can override this if necessary, but such a need is
+     * (Purposely inherit JavaDoc and semantics from LoopTag. Subclasses can override this if necessary, but such a need is
      * expected to be rare.)
      */
+    @Override
     public Object getCurrent() {
         return item;
     }
 
     /*
-     * (Purposely inherit JavaDoc and semantics from LoopTag.
-     * Subclasses can override this method for more fine-grained control
-     * over LoopTagStatus, but an effort has been made to simplify
-     * implementation of subclasses that are happy with reasonable default
-     * behavior.)
+     * (Purposely inherit JavaDoc and semantics from LoopTag. Subclasses can override this method for more fine-grained
+     * control over LoopTagStatus, but an effort has been made to simplify implementation of subclasses that are happy with
+     * reasonable default behavior.)
      */
+    @Override
     public LoopTagStatus getLoopStatus() {
 
         // local implementation with reasonable default behavior
         class Status implements LoopTagStatus {
 
             /*
-             * All our methods are straightforward.  We inherit
-             * our JavaDoc from LoopTagSupport; see that class
-             * for more information.
+             * All our methods are straightforward. We inherit our JavaDoc from LoopTagSupport; see that class for more information.
              */
 
+            @Override
             public Object getCurrent() {
                 /*
-                 * Access the item through getCurrent() instead of just
-                 * returning the item our containing class stores.  This
-                 * should allow a subclass of LoopTagSupport to override
-                 * getCurrent() without having to rewrite getLoopStatus() too.
+                 * Access the item through getCurrent() instead of just returning the item our containing class stores. This should
+                 * allow a subclass of LoopTagSupport to override getCurrent() without having to rewrite getLoopStatus() too.
                  */
-                return (LoopTagSupport.this.getCurrent());
+                return LoopTagSupport.this.getCurrent();
             }
+
+            @Override
             public int getIndex() {
-                return (index + begin);       // our 'index' isn't getIndex()
+                return index + begin; // our 'index' isn't getIndex()
             }
+
+            @Override
             public int getCount() {
-                return (count);
+                return count;
             }
+
+            @Override
             public boolean isFirst() {
-                return (index == 0);          // our 'index' isn't getIndex()
+                return index == 0; // our 'index' isn't getIndex()
             }
+
+            @Override
             public boolean isLast() {
-                return (last);                // use cached value
+                return last; // use cached value
             }
+
+            @Override
             public Integer getBegin() {
-                if (beginSpecified)
+                if (beginSpecified) {
                     return Integer.valueOf(begin);
-                else
+                } else {
                     return null;
+                }
             }
+
+            @Override
             public Integer getEnd() {
-                if (endSpecified)
+                if (endSpecified) {
                     return Integer.valueOf(end);
-                else
+                } else {
                     return null;
+                }
             }
+
+            @Override
             public Integer getStep() {
-                if (stepSpecified)
+                if (stepSpecified) {
                     return Integer.valueOf(step);
-                else
+                } else {
                     return null;
+                }
             }
         }
 
         /*
-         * We just need one per invocation...  Actually, for the current
-         * implementation, we just need one per instance, but I'd rather
-         * not keep the reference around once release() has been called.
+         * We just need one per invocation... Actually, for the current implementation, we just need one per instance, but I'd
+         * rather not keep the reference around once release() has been called.
          */
-        if (status == null)
+        if (status == null) {
             status = new Status();
+        }
 
         return status;
     }
 
     /*
-     * Get the delimiter for string tokens.  Used only for constructing
-     * the deferred expression for it.
+     * Get the delimiter for string tokens. Used only for constructing the deferred expression for it.
      */
     protected String getDelims() {
         return ",";
     }
 
     /*
-     * We only support setter methods for attributes that need to be
-     * offered as Strings or other literals; other attributes will be
-     * handled directly by implementing classes, since there might be
-     * both rtexprvalue- and EL-based varieties, which will have
-     * different signatures.  (We can't pollute child classes by having
-     * base implementations of those setters here; child classes that
-     * have attributes with different signatures would end up having
-     * two incompatible setters, which is illegal for a JavaBean.
+     * We only support setter methods for attributes that need to be offered as Strings or other literals; other attributes
+     * will be handled directly by implementing classes, since there might be both rtexprvalue- and EL-based varieties,
+     * which will have different signatures. (We can't pollute child classes by having base implementations of those setters
+     * here; child classes that have attributes with different signatures would end up having two incompatible setters,
+     * which is illegal for a JavaBean.
      */
 
     /**
      * Sets the 'var' attribute.
      *
-     * @param id Name of the exported scoped variable storing the current item
-     * of the iteration.
+     * @param id Name of the exported scoped variable storing the current item of the iteration.
      */
     public void setVar(String id) {
         this.itemId = id;
@@ -445,165 +433,149 @@ public abstract class LoopTagSupport
     /**
      * Sets the 'varStatus' attribute.
      *
-     * @param statusId Name of the exported scoped variable storing the status
-     * of the iteration.
+     * @param statusId Name of the exported scoped variable storing the status of the iteration.
      */
     public void setVarStatus(String statusId) {
         this.statusId = statusId;
     }
 
-
-    //*********************************************************************
+    // *********************************************************************
     // Protected utility methods
 
-    /* 
-     * These methods validate attributes common to iteration tags.
-     * Call them if your own subclassing implementation modifies them
-     * -- e.g., if you set them through an expression language.
+    /*
+     * These methods validate attributes common to iteration tags. Call them if your own subclassing implementation modifies
+     * them -- e.g., if you set them through an expression language.
      */
 
     /**
-     * Ensures the "begin" property is sensible, throwing an exception
-     * expected to propagate up if it isn't
+     * Ensures the "begin" property is sensible, throwing an exception expected to propagate up if it isn't
      */
     protected void validateBegin() throws JspTagException {
-        if (begin < 0)
+        if (begin < 0) {
             throw new JspTagException("'begin' < 0");
+        }
     }
 
     /**
-     * Ensures the "end" property is sensible, throwing an exception
-     * expected to propagate up if it isn't
+     * Ensures the "end" property is sensible, throwing an exception expected to propagate up if it isn't
      */
     protected void validateEnd() throws JspTagException {
-        if (end < 0)
+        if (end < 0) {
             throw new JspTagException("'end' < 0");
+        }
     }
 
     /**
-     * Ensures the "step" property is sensible, throwing an exception
-     * expected to propagate up if it isn't
+     * Ensures the "step" property is sensible, throwing an exception expected to propagate up if it isn't
      */
     protected void validateStep() throws JspTagException {
-        if (step < 1)
+        if (step < 1) {
             throw new JspTagException("'step' <= 0");
+        }
     }
 
-
-    //*********************************************************************
+    // *********************************************************************
     // Private utility methods
 
     /** (Re)initializes state (during release() or construction) */
     private void init() {
         // defaults for internal bookkeeping
-        index = 0;              // internal index always starts at 0
-        count = 1;              // internal count always starts at 1
-        status = null;          // we clear status on release()
-        item = null;            // item will be retrieved for each round
-        last = false;           // last must be set explicitly
+        index = 0; // internal index always starts at 0
+        count = 1; // internal count always starts at 1
+        status = null; // we clear status on release()
+        item = null; // item will be retrieved for each round
+        last = false; // last must be set explicitly
         beginSpecified = false; // not specified until it's specified :-)
-        endSpecified = false;   // (as above)
-        stepSpecified = false;  // (as above)
+        endSpecified = false; // (as above)
+        stepSpecified = false; // (as above)
 
         // defaults for interface with page author
-        begin = 0;              // when not specified, 'begin' is 0 by spec.
-        end = -1;               // when not specified, 'end' is not used
-        step = 1;               // when not specified, 'step' is 1
-        itemId = null;          // when not specified, no variable exported
-        statusId = null;        // when not specified, no variable exported
+        begin = 0; // when not specified, 'begin' is 0 by spec.
+        end = -1; // when not specified, 'end' is not used
+        step = 1; // when not specified, 'step' is 1
+        itemId = null; // when not specified, no variable exported
+        statusId = null; // when not specified, no variable exported
     }
 
     /** Sets 'last' appropriately. */
     private void calibrateLast() throws JspTagException {
         /*
-         * the current round is the last one if (a) there are no remaining
-         * elements, or (b) the next one is beyond the 'end'.
+         * the current round is the last one if (a) there are no remaining elements, or (b) the next one is beyond the 'end'.
          */
-        last = !hasNext() || atEnd() ||
-            (end != -1 && (begin + index + step > end));
+        last = !hasNext() || atEnd() || end != -1 && begin + index + step > end;
     }
 
     /**
-     * Exposes attributes (formerly scripting variables, but no longer!)
-     * if appropriate.  Note that we don't really care, here, whether they're
-     * scripting variables or not.
+     * Exposes attributes (formerly scripting variables, but no longer!) if appropriate. Note that we don't really care,
+     * here, whether they're scripting variables or not.
      */
     private void exposeVariables(boolean firstTime) throws JspTagException {
 
         /*
-         * We need to support null items returned from next(); we
-         * do this simply by passing such non-items through to the
-         * scoped variable as effectively 'null' (that is, by calling
-         * removeAttribute()).
+         * We need to support null items returned from next(); we do this simply by passing such non-items through to the scoped
+         * variable as effectively 'null' (that is, by calling removeAttribute()).
          *
-         * Also, just to be defensive, we handle the case of a null
-         * 'status' object as well.
+         * Also, just to be defensive, we handle the case of a null 'status' object as well.
          *
-         * We call getCurrent() and getLoopStatus() (instead of just using
-         * 'item' and 'status') to bridge to subclasses correctly.
-         * A subclass can override getCurrent() or getLoopStatus() but still
-         * depend on our doStartTag() and doAfterBody(), which call this
-         * method (exposeVariables()), to expose 'item' and 'status'
-         * correctly.
+         * We call getCurrent() and getLoopStatus() (instead of just using 'item' and 'status') to bridge to subclasses
+         * correctly. A subclass can override getCurrent() or getLoopStatus() but still depend on our doStartTag() and
+         * doAfterBody(), which call this method (exposeVariables()), to expose 'item' and 'status' correctly.
          */
 
         if (itemId != null) {
-            if (getCurrent() == null)
+            if (getCurrent() == null) {
                 pageContext.removeAttribute(itemId, PageContext.PAGE_SCOPE);
-            else if (deferredExpression != null) {
-                VariableMapper vm = 
-                    pageContext.getELContext().getVariableMapper();
+            } else if (deferredExpression != null) {
+                VariableMapper vm = pageContext.getELContext().getVariableMapper();
                 if (vm != null) {
                     ValueExpression ve = getVarExpression(deferredExpression);
                     ValueExpression tmpValue = vm.setVariable(itemId, ve);
-                    if (firstTime)
+                    if (firstTime) {
                         oldMappedValue = tmpValue;
+                    }
                 }
-            } else
+            } else {
                 pageContext.setAttribute(itemId, getCurrent());
+            }
         }
         if (statusId != null) {
-            if (getLoopStatus() == null)
+            if (getLoopStatus() == null) {
                 pageContext.removeAttribute(statusId, PageContext.PAGE_SCOPE);
-            else
+            } else {
                 pageContext.setAttribute(statusId, getLoopStatus());
+            }
         }
 
     }
 
     /**
-     * Removes page attributes that we have exposed and, if applicable,
-     * restores them to their prior values (and scopes).
+     * Removes page attributes that we have exposed and, if applicable, restores them to their prior values (and scopes).
      */
     private void unExposeVariables() {
         // "nested" variables are now simply removed
-	if (itemId != null) {
+        if (itemId != null) {
             pageContext.removeAttribute(itemId, PageContext.PAGE_SCOPE);
             VariableMapper vm = pageContext.getELContext().getVariableMapper();
-            if (vm != null)
+            if (vm != null) {
                 vm.setVariable(itemId, oldMappedValue);
+            }
         }
-	if (statusId != null)
-	    pageContext.removeAttribute(statusId, PageContext.PAGE_SCOPE);
+        if (statusId != null) {
+            pageContext.removeAttribute(statusId, PageContext.PAGE_SCOPE);
+        }
     }
 
     /**
-     * Cycles through and discards up to 'n' items from the iteration.
-     * We only know "up to 'n'", not "exactly n," since we stop cycling
-     * if hasNext() returns false or if we hit the 'end' of the iteration.
-     * Note: this does not update the iteration index, since this method
-     * is intended as a behind-the-scenes operation.  The index must be
-     * updated separately.  (I don't really like this, but it's the simplest
-     * way to support isLast() without storing two separate inconsistent
-     * indices.  We need to (a) make sure hasNext() refers to the next
-     * item we actually *want* and (b) make sure the index refers to the
-     * item associated with the *current* round, not the next one.
-     * C'est la vie.)
+     * Cycles through and discards up to 'n' items from the iteration. We only know "up to 'n'", not "exactly n," since we
+     * stop cycling if hasNext() returns false or if we hit the 'end' of the iteration. Note: this does not update the
+     * iteration index, since this method is intended as a behind-the-scenes operation. The index must be updated
+     * separately. (I don't really like this, but it's the simplest way to support isLast() without storing two separate
+     * inconsistent indices. We need to (a) make sure hasNext() refers to the next item we actually *want* and (b) make sure
+     * the index refers to the item associated with the *current* round, not the next one. C'est la vie.)
      */
     private void discard(int n) throws JspTagException {
         /*
-         * copy index so we can restore it, but we need to update it
-         * as we work so that atEnd() works
+         * copy index so we can restore it, but we need to update it as we work so that atEnd() works
          */
         int oldIndex = index;
         while (n-- > 0 && !atEnd() && hasNext()) {
@@ -614,46 +586,41 @@ public abstract class LoopTagSupport
     }
 
     /**
-     * Discards items ignoring subsetting rules.  Useful for discarding
-     * items from the beginning (i.e., to implement 'begin') where we
-     * don't want factor in the 'begin' value already.
+     * Discards items ignoring subsetting rules. Useful for discarding items from the beginning (i.e., to implement 'begin')
+     * where we don't want factor in the 'begin' value already.
      */
     private void discardIgnoreSubset(int n) throws JspTagException {
-	while (n-- > 0 && hasNext())
-	    next();
+        while (n-- > 0 && hasNext()) {
+            next();
+        }
     }
 
     /**
-     * Returns true if the iteration has past the 'end' index (with
-     * respect to subsetting), false otherwise.  ('end' must be set
-     * for atEnd() to return true; if 'end' is not set, atEnd()
-     * always returns false.)
+     * Returns true if the iteration has past the 'end' index (with respect to subsetting), false otherwise. ('end' must be
+     * set for atEnd() to return true; if 'end' is not set, atEnd() always returns false.)
      */
     private boolean atEnd() {
-        return ((end != -1) && (begin + index >= end));
+        return end != -1 && begin + index >= end;
     }
 
     private ValueExpression getVarExpression(ValueExpression expr) {
         Object o = expr.getValue(pageContext.getELContext());
-        if (o == null)
+        if (o == null) {
             return null;
+        }
 
         if (o.getClass().isArray() || o instanceof List) {
-            return new IndexedValueExpression(deferredExpression, index+begin);
+            return new IndexedValueExpression(deferredExpression, index + begin);
         }
 
-        if (o instanceof Collection || o instanceof Iterator ||
-            o instanceof Enumeration || o instanceof Map ||
-            o instanceof String) {
+        if (o instanceof Collection || o instanceof Iterator || o instanceof Enumeration || o instanceof Map || o instanceof String) {
 
             if (iteratedExpression == null) {
-                iteratedExpression =
-                    new IteratedExpression(deferredExpression, getDelims());
+                iteratedExpression = new IteratedExpression(deferredExpression, getDelims());
             }
-            return new IteratedValueExpression(iteratedExpression, index+begin);
+            return new IteratedValueExpression(iteratedExpression, index + begin);
         }
 
-        throw new ELException("Don't know how to iterate over supplied "
-                              + "items in forEach");
+        throw new ELException("Don't know how to iterate over supplied " + "items in forEach");
     }
 }

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/fmt/LocaleSupport.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/fmt/LocaleSupport.java
@@ -29,13 +29,11 @@ import jakarta.servlet.jsp.PageContext;
 import jakarta.servlet.jsp.jstl.core.Config;
 
 /**
- * Class which exposes the locale-determination logic for resource bundles
- * through convenience methods.
+ * Class which exposes the locale-determination logic for resource bundles through convenience methods.
  *
- * <p> This class may be useful to any tag handler implementation that needs
- * to produce localized messages. For example, this might be useful for 
- * exception messages that are intended directly for user consumption on an 
- * error page.
+ * <p>
+ * This class may be useful to any tag handler implementation that needs to produce localized messages. For example,
+ * this might be useful for exception messages that are intended directly for user consumption on an error page.
  *
  * @author Jan Luehe
  */
@@ -45,474 +43,398 @@ public class LocaleSupport {
     private static final String UNDEFINED_KEY = "???";
     private static final char HYPHEN = '-';
     private static final char UNDERSCORE = '_';
-    private static final String REQUEST_CHAR_SET =
-        "jakarta.servlet.jsp.jstl.fmt.request.charset";
+    private static final String REQUEST_CHAR_SET = "jakarta.servlet.jsp.jstl.fmt.request.charset";
     private static final Locale EMPTY_LOCALE = new Locale("", "");
 
-    /** 
+    /**
      * Retrieves the localized message corresponding to the given key.
      *
-     * <p> The given key is looked up in the resource bundle of the default
-     * I18N localization context, which is retrieved from the
-     * <tt>jakarta.servlet.jsp.jstl.fmt.localizationContext</tt> configuration
-     * setting.
+     * <p>
+     * The given key is looked up in the resource bundle of the default I18N localization context, which is retrieved from
+     * the <tt>jakarta.servlet.jsp.jstl.fmt.localizationContext</tt> configuration setting.
      *
-     * <p> If the configuration setting is empty, or the default I18N
-     * localization context does not contain any resource bundle, or the given
-     * key is undefined in its resource bundle, the string "???&lt;key&gt;???" is
-     * returned, where "&lt;key&gt;" is replaced with the given key.
-     * 
-     * @param pageContext the page in which to get the localized message
-     * corresponding to the given key  
+     * <p>
+     * If the configuration setting is empty, or the default I18N localization context does not contain any resource bundle,
+     * or the given key is undefined in its resource bundle, the string "???&lt;key&gt;???" is returned, where "&lt;key&gt;"
+     * is replaced with the given key.
+     *
+     * @param pageContext the page in which to get the localized message corresponding to the given key
      * @param key the message key
-     * 
-     * @return the localized message corresponding to the given key 
-     */ 
-    public static String getLocalizedMessage(PageContext pageContext, 
-                                             String key) {
-	return getLocalizedMessage(pageContext, key, null, null);
-    }
-
-    /** 
-     * Retrieves the localized message corresponding to the given key.
      *
-     * <p> The given key is looked up in the resource bundle with the given
-     * base name.
-     *
-     * <p> If no resource bundle with the given base name exists, or the given
-     * key is undefined in the resource bundle, the string "???&lt;key&gt;???" is
-     * returned, where "&lt;key&gt;" is replaced with the given key.
-     * 
-     * @param pageContext the page in which to get the localized message
-     * corresponding to the given key  
-     * @param key the message key
-     * @param basename the resource bundle base name 
-     * 
-     * @return the localized message corresponding to the given key 
-     */ 
-    public static String getLocalizedMessage(PageContext pageContext, 
-                                             String key, 
-                                             String basename) {
-	return getLocalizedMessage(pageContext, key, null, basename);
+     * @return the localized message corresponding to the given key
+     */
+    public static String getLocalizedMessage(PageContext pageContext, String key) {
+        return getLocalizedMessage(pageContext, key, null, null);
     }
 
     /**
-     * Retrieves the localized message corresponding to the given key, and
-     * performs parametric replacement using the arguments specified via
-     * <tt>args</tt>.
+     * Retrieves the localized message corresponding to the given key.
      *
-     * <p> See the specification of the &lt;fmt:message&gt; action for a description
-     * of how parametric replacement is implemented.
+     * <p>
+     * The given key is looked up in the resource bundle with the given base name.
      *
-     * <p> The localized message is retrieved as in
+     * <p>
+     * If no resource bundle with the given base name exists, or the given key is undefined in the resource bundle, the
+     * string "???&lt;key&gt;???" is returned, where "&lt;key&gt;" is replaced with the given key.
+     *
+     * @param pageContext the page in which to get the localized message corresponding to the given key
+     * @param key the message key
+     * @param basename the resource bundle base name
+     *
+     * @return the localized message corresponding to the given key
+     */
+    public static String getLocalizedMessage(PageContext pageContext, String key, String basename) {
+        return getLocalizedMessage(pageContext, key, null, basename);
+    }
+
+    /**
+     * Retrieves the localized message corresponding to the given key, and performs parametric replacement using the
+     * arguments specified via <tt>args</tt>.
+     *
+     * <p>
+     * See the specification of the &lt;fmt:message&gt; action for a description of how parametric replacement is
+     * implemented.
+     *
+     * <p>
+     * The localized message is retrieved as in
      * {@link #getLocalizedMessage(jakarta.servlet.jsp.PageContext,java.lang.String) getLocalizedMessage(pageContext, key)}.
      *
-     * @param pageContext the page in which to get the localized message
-     * corresponding to the given key  
+     * @param pageContext the page in which to get the localized message corresponding to the given key
      * @param key the message key
-     * @param args the arguments for parametric replacement 
-     * 
-     * @return the localized message corresponding to the given key 
-     */ 
-    public static String getLocalizedMessage(PageContext pageContext, 
-                                             String key, 
-                                             Object[] args) {
-	return getLocalizedMessage(pageContext, key, args, null);
+     * @param args the arguments for parametric replacement
+     *
+     * @return the localized message corresponding to the given key
+     */
+    public static String getLocalizedMessage(PageContext pageContext, String key, Object[] args) {
+        return getLocalizedMessage(pageContext, key, args, null);
     }
 
     /**
-     * Retrieves the localized message corresponding to the given key, and
-     * performs parametric replacement using the arguments specified via
-     * <tt>args</tt>.
+     * Retrieves the localized message corresponding to the given key, and performs parametric replacement using the
+     * arguments specified via <tt>args</tt>.
      *
-     * <p> See the specification of the &lt;fmt:message&gt; action for a description
-     * of how parametric replacement is implemented.
+     * <p>
+     * See the specification of the &lt;fmt:message&gt; action for a description of how parametric replacement is
+     * implemented.
      *
-     * <p> The localized message is retrieved as in
-     * {@link #getLocalizedMessage(jakarta.servlet.jsp.PageContext,java.lang.String, java.lang.String) getLocalizedMessage(pageContext, key, basename)}.
-     * 
-     * @param pageContext the page in which to get the localized message
-     * corresponding to the given key  
+     * <p>
+     * The localized message is retrieved as in
+     * {@link #getLocalizedMessage(jakarta.servlet.jsp.PageContext,java.lang.String, java.lang.String)
+     * getLocalizedMessage(pageContext, key, basename)}.
+     *
+     * @param pageContext the page in which to get the localized message corresponding to the given key
      * @param key the message key
-     * @param args the arguments for parametric replacement 
-     * @param basename the resource bundle base name 
-     * 
-     * @return the localized message corresponding to the given key 
-     */ 
-    public static String getLocalizedMessage(PageContext pageContext, 
-                                             String key, 
-                                             Object[] args, 
-                                             String basename) {
-	LocalizationContext locCtxt = null;
-	String message = UNDEFINED_KEY + key + UNDEFINED_KEY;
+     * @param args the arguments for parametric replacement
+     * @param basename the resource bundle base name
+     *
+     * @return the localized message corresponding to the given key
+     */
+    public static String getLocalizedMessage(PageContext pageContext, String key, Object[] args, String basename) {
+        LocalizationContext locCtxt = null;
+        String message = UNDEFINED_KEY + key + UNDEFINED_KEY;
 
-	if (basename != null) {
-	    locCtxt = getLocalizationContext(pageContext, basename);
-	} else {
-	    locCtxt = getLocalizationContext(pageContext);
-	}
+        if (basename != null) {
+            locCtxt = getLocalizationContext(pageContext, basename);
+        } else {
+            locCtxt = getLocalizationContext(pageContext);
+        }
 
-	if (locCtxt != null) {
-	    ResourceBundle bundle = locCtxt.getResourceBundle();
-	    if (bundle != null) {
-		try {
-		    message = bundle.getString(key);
-		    if (args != null) {
-			MessageFormat formatter = new MessageFormat("");
-			if (locCtxt.getLocale() != null) {
-			    formatter.setLocale(locCtxt.getLocale());
-			}
-			formatter.applyPattern(message);
-			message = formatter.format(args);
-		    }
-		} catch (MissingResourceException mre) {
-		}
-	    }
-	}
+        if (locCtxt != null) {
+            ResourceBundle bundle = locCtxt.getResourceBundle();
+            if (bundle != null) {
+                try {
+                    message = bundle.getString(key);
+                    if (args != null) {
+                        MessageFormat formatter = new MessageFormat("");
+                        if (locCtxt.getLocale() != null) {
+                            formatter.setLocale(locCtxt.getLocale());
+                        }
+                        formatter.applyPattern(message);
+                        message = formatter.format(args);
+                    }
+                } catch (MissingResourceException mre) {
+                }
+            }
+        }
 
-	return message;
+        return message;
     }
-
 
     /**
      * Gets the default I18N localization context.
      *
      * @param pc Page in which to look up the default I18N localization context
-     */    
+     */
     private static LocalizationContext getLocalizationContext(PageContext pc) {
-	LocalizationContext locCtxt = null;
+        LocalizationContext locCtxt = null;
 
-	Object obj = Config.find(pc, Config.FMT_LOCALIZATION_CONTEXT);
-	if (obj == null) {
-	    return null;
-	}
+        Object obj = Config.find(pc, Config.FMT_LOCALIZATION_CONTEXT);
+        if (obj == null) {
+            return null;
+        }
 
-	if (obj instanceof LocalizationContext) {
-	    locCtxt = (LocalizationContext) obj;
-	} else {
-	    // localization context is a bundle basename
-	    locCtxt = getLocalizationContext(pc, (String) obj);
-	}
+        if (obj instanceof LocalizationContext) {
+            locCtxt = (LocalizationContext) obj;
+        } else {
+            // localization context is a bundle basename
+            locCtxt = getLocalizationContext(pc, (String) obj);
+        }
 
-	return locCtxt;
+        return locCtxt;
     }
 
     /**
-     * Gets the resource bundle with the given base name, whose locale is
-     * determined as follows:
+     * Gets the resource bundle with the given base name, whose locale is determined as follows:
      *
-     * Check if a match exists between the ordered set of preferred
-     * locales and the available locales, for the given base name.
-     * The set of preferred locales consists of a single locale
-     * (if the <tt>jakarta.servlet.jsp.jstl.fmt.locale</tt> configuration
-     * setting is present) or is equal to the client's preferred locales
-     * determined from the client's browser settings.
+     * Check if a match exists between the ordered set of preferred locales and the available locales, for the given base
+     * name. The set of preferred locales consists of a single locale (if the <tt>jakarta.servlet.jsp.jstl.fmt.locale</tt>
+     * configuration setting is present) or is equal to the client's preferred locales determined from the client's browser
+     * settings.
      *
-     * <p> If no match was found in the previous step, check if a match
-     * exists between the fallback locale (given by the
-     * <tt>jakarta.servlet.jsp.jstl.fmt.fallbackLocale</tt> configuration
-     * setting) and the available locales, for the given base name.
+     * <p>
+     * If no match was found in the previous step, check if a match exists between the fallback locale (given by the
+     * <tt>jakarta.servlet.jsp.jstl.fmt.fallbackLocale</tt> configuration setting) and the available locales, for the given
+     * base name.
      *
-     * @param pageContext Page in which the resource bundle with the
-     * given base name is requested
+     * @param pageContext Page in which the resource bundle with the given base name is requested
      * @param basename Resource bundle base name
      *
-     * @return Localization context containing the resource bundle with the
-     * given base name and the locale that led to the resource bundle match,
-     * or the empty localization context if no resource bundle match was found
+     * @return Localization context containing the resource bundle with the given base name and the locale that led to the
+     * resource bundle match, or the empty localization context if no resource bundle match was found
      */
-    private static LocalizationContext getLocalizationContext(PageContext pc,
-                                                              String basename) {
-	LocalizationContext locCtxt = null;
-	ResourceBundle bundle = null;
+    private static LocalizationContext getLocalizationContext(PageContext pc, String basename) {
+        LocalizationContext locCtxt = null;
+        ResourceBundle bundle = null;
 
-	if ((basename == null) || basename.equals("")) {
-	    return new LocalizationContext();
-	}
+        if (basename == null || basename.equals("")) {
+            return new LocalizationContext();
+        }
 
-	// Try preferred locales
-	Locale pref = getLocale(pc, Config.FMT_LOCALE);
-	if (pref != null) {
-	    // Preferred locale is application-based
-	    bundle = findMatch(basename, pref);
-	    if (bundle != null) {
-		locCtxt = new LocalizationContext(bundle, pref);
-	    }
-	} else {
-	    // Preferred locales are browser-based
-	    locCtxt = findMatch(pc, basename);
-	}
-	
-	if (locCtxt == null) {
-	    // No match found with preferred locales, try using fallback locale
-	    pref = getLocale(pc, Config.FMT_FALLBACK_LOCALE);
-	    if (pref != null) {
-		bundle = findMatch(basename, pref);
-		if (bundle != null) {
-		    locCtxt = new LocalizationContext(bundle, pref);
-		}
-	    }
-	}
+        // Try preferred locales
+        Locale pref = getLocale(pc, Config.FMT_LOCALE);
+        if (pref != null) {
+            // Preferred locale is application-based
+            bundle = findMatch(basename, pref);
+            if (bundle != null) {
+                locCtxt = new LocalizationContext(bundle, pref);
+            }
+        } else {
+            // Preferred locales are browser-based
+            locCtxt = findMatch(pc, basename);
+        }
 
-	if (locCtxt == null) {
-	    // try using the root resource bundle with the given basename
-	    try {
-		bundle = ResourceBundle.getBundle(basename, EMPTY_LOCALE,
-						  Thread.currentThread().getContextClassLoader());
-		if (bundle != null) {
-		    locCtxt = new LocalizationContext(bundle, null);
-		}
-	    } catch (MissingResourceException mre) {
-		// do nothing
-	    }
-	}
-		 
-	if (locCtxt != null) {
-	    // set response locale
-	    if (locCtxt.getLocale() != null) {
-		setResponseLocale(pc, locCtxt.getLocale());
-	    }
-	} else {
-	    // create empty localization context
-	    locCtxt = new LocalizationContext();
-	}
+        if (locCtxt == null) {
+            // No match found with preferred locales, try using fallback locale
+            pref = getLocale(pc, Config.FMT_FALLBACK_LOCALE);
+            if (pref != null) {
+                bundle = findMatch(basename, pref);
+                if (bundle != null) {
+                    locCtxt = new LocalizationContext(bundle, pref);
+                }
+            }
+        }
 
-	return locCtxt;
+        if (locCtxt == null) {
+            // try using the root resource bundle with the given basename
+            try {
+                bundle = ResourceBundle.getBundle(basename, EMPTY_LOCALE, Thread.currentThread().getContextClassLoader());
+                if (bundle != null) {
+                    locCtxt = new LocalizationContext(bundle, null);
+                }
+            } catch (MissingResourceException mre) {
+                // do nothing
+            }
+        }
+
+        if (locCtxt != null) {
+            // set response locale
+            if (locCtxt.getLocale() != null) {
+                setResponseLocale(pc, locCtxt.getLocale());
+            }
+        } else {
+            // create empty localization context
+            locCtxt = new LocalizationContext();
+        }
+
+        return locCtxt;
     }
 
     /*
-     * Determines the client's preferred locales from the request, and compares
-     * each of the locales (in order of preference) against the available
-     * locales in order to determine the best matching locale.
+     * Determines the client's preferred locales from the request, and compares each of the locales (in order of preference)
+     * against the available locales in order to determine the best matching locale.
      *
-     * @param pageContext the page in which the resource bundle with the
-     * given base name is requested
+     * @param pageContext the page in which the resource bundle with the given base name is requested
+     *
      * @param basename the resource bundle's base name
      *
-     * @return the localization context containing the resource bundle with
-     * the given base name and best matching locale, or <tt>null</tt> if no
-     * resource bundle match was found
+     * @return the localization context containing the resource bundle with the given base name and best matching locale, or
+     * <tt>null</tt> if no resource bundle match was found
      */
-    private static LocalizationContext findMatch(PageContext pageContext,
-						 String basename) {
-	LocalizationContext locCtxt = null;
-	
-	// Determine locale from client's browser settings.
-        
-	for (Enumeration enum_ = getRequestLocales(
-                            (HttpServletRequest)pageContext.getRequest());
-	     enum_.hasMoreElements(); ) {
-	    Locale pref = (Locale) enum_.nextElement();
-	    ResourceBundle match = findMatch(basename, pref);
-	    if (match != null) {
-		locCtxt = new LocalizationContext(match, pref);
-		break;
-	    }
-	}
-        	
-	return locCtxt;
+    private static LocalizationContext findMatch(PageContext pageContext, String basename) {
+        LocalizationContext locCtxt = null;
+
+        // Determine locale from client's browser settings.
+
+        for (Enumeration enum_ = getRequestLocales((HttpServletRequest) pageContext.getRequest()); enum_.hasMoreElements();) {
+            Locale pref = (Locale) enum_.nextElement();
+            ResourceBundle match = findMatch(basename, pref);
+            if (match != null) {
+                locCtxt = new LocalizationContext(match, pref);
+                break;
+            }
+        }
+
+        return locCtxt;
     }
 
     /*
      * Gets the resource bundle with the given base name and preferred locale.
-     * 
-     * This method calls java.util.ResourceBundle.getBundle(), but ignores
-     * its return value unless its locale represents an exact or language match
-     * with the given preferred locale.
+     *
+     * This method calls java.util.ResourceBundle.getBundle(), but ignores its return value unless its locale represents an
+     * exact or language match with the given preferred locale.
      *
      * @param basename the resource bundle base name
+     *
      * @param pref the preferred locale
      *
-     * @return the requested resource bundle, or <tt>null</tt> if no resource
-     * bundle with the given base name exists or if there is no exact- or
-     * language-match between the preferred locale and the locale of
-     * the bundle returned by java.util.ResourceBundle.getBundle().
+     * @return the requested resource bundle, or <tt>null</tt> if no resource bundle with the given base name exists or if
+     * there is no exact- or language-match between the preferred locale and the locale of the bundle returned by
+     * java.util.ResourceBundle.getBundle().
      */
     private static ResourceBundle findMatch(String basename, Locale pref) {
-	ResourceBundle match = null;
+        ResourceBundle match = null;
 
-	try {
-	    ResourceBundle bundle =
-		ResourceBundle.getBundle(basename, pref,
-					 Thread.currentThread().getContextClassLoader());
-	    Locale avail = bundle.getLocale();
-	    if (pref.equals(avail)) {
-		// Exact match
-		match = bundle;
-	    } else {
-                /*
-                 * We have to make sure that the match we got is for
-                 * the specified locale. The way ResourceBundle.getBundle()
-                 * works, if a match is not found with (1) the specified locale,
-                 * it tries to match with (2) the current default locale as 
-                 * returned by Locale.getDefault() or (3) the root resource 
-                 * bundle (basename).
-                 * We must ignore any match that could have worked with (2) or (3).
-                 * So if an exact match is not found, we make the following extra
-                 * tests:
-                 *     - avail locale must be equal to preferred locale
-                 *     - avail country must be empty or equal to preferred country
-                 *       (the equality match might have failed on the variant)
-		 */
-                if (pref.getLanguage().equals(avail.getLanguage())
-		    && ("".equals(avail.getCountry()) || pref.getCountry().equals(avail.getCountry()))) {
-		    /*
-		     * Language match.
-		     * By making sure the available locale does not have a 
-		     * country and matches the preferred locale's language, we
-		     * rule out "matches" based on the container's default
-		     * locale. For example, if the preferred locale is 
-		     * "en-US", the container's default locale is "en-UK", and
-		     * there is a resource bundle (with the requested base
-		     * name) available for "en-UK", ResourceBundle.getBundle()
-		     * will return it, but even though its language matches
-		     * that of the preferred locale, we must ignore it,
-		     * because matches based on the container's default locale
-		     * are not portable across different containers with
-		     * different default locales.
-		     */
-		    match = bundle;
-		}
-	    }
-	} catch (MissingResourceException mre) {
-	}
+        try {
+            ResourceBundle bundle = ResourceBundle.getBundle(basename, pref, Thread.currentThread().getContextClassLoader());
+            Locale avail = bundle.getLocale();
+            if (pref.equals(avail) || (pref.getLanguage().equals(avail.getLanguage()) && ("".equals(avail.getCountry()) || pref.getCountry().equals(avail.getCountry())))) {
+                // Exact match
+                match = bundle;
+            }
+        } catch (MissingResourceException mre) {
+        }
 
-	return match;
+        return match;
     }
 
     /*
-     * Returns the locale specified by the named scoped attribute or context
+     * Returns the locale specified by the named scoped attribute or context configuration parameter.
+     *
+     * <p> The named scoped attribute is searched in the page, request, session (if valid), and application scope(s) (in
+     * this order). If no such attribute exists in any of the scopes, the locale is taken from the named context
      * configuration parameter.
      *
-     * <p> The named scoped attribute is searched in the page, request,
-     * session (if valid), and application scope(s) (in this order). If no such
-     * attribute exists in any of the scopes, the locale is taken from the
-     * named context configuration parameter.
+     * @param pageContext the page in which to search for the named scoped attribute or context configuration parameter
      *
-     * @param pageContext the page in which to search for the named scoped
-     * attribute or context configuration parameter
-     * @param name the name of the scoped attribute or context configuration
-     * parameter
+     * @param name the name of the scoped attribute or context configuration parameter
      *
-     * @return the locale specified by the named scoped attribute or context
-     * configuration parameter, or <tt>null</tt> if no scoped attribute or
-     * configuration parameter with the given name exists
+     * @return the locale specified by the named scoped attribute or context configuration parameter, or <tt>null</tt> if no
+     * scoped attribute or configuration parameter with the given name exists
      */
     private static Locale getLocale(PageContext pageContext, String name) {
-	Locale loc = null;
+        Locale loc = null;
 
-	Object obj = Config.find(pageContext, name);
-	if (obj != null) {
-	    if (obj instanceof Locale) {
-		loc = (Locale) obj;
-	    } else {
-		loc = parseLocale((String) obj);
-	    }
-	}
+        Object obj = Config.find(pageContext, name);
+        if (obj != null) {
+            if (obj instanceof Locale) {
+                loc = (Locale) obj;
+            } else {
+                loc = parseLocale((String) obj);
+            }
+        }
 
-	return loc;
+        return loc;
     }
 
     /*
-     * Stores the given locale in the response object of the given page
-     * context, and stores the locale's associated charset in the
-     * jakarta.servlet.jsp.jstl.fmt.request.charset session attribute, which
-     * may be used by the <requestEncoding> action in a page invoked by a
-     * form included in the response to set the request charset to the same as
-     * the response charset (this makes it possible for the container to
-     * decode the form parameter values properly, since browsers typically
-     * encode form field values using the response's charset).
+     * Stores the given locale in the response object of the given page context, and stores the locale's associated charset
+     * in the jakarta.servlet.jsp.jstl.fmt.request.charset session attribute, which may be used by the <requestEncoding>
+     * action in a page invoked by a form included in the response to set the request charset to the same as the response
+     * charset (this makes it possible for the container to decode the form parameter values properly, since browsers
+     * typically encode form field values using the response's charset).
      *
-     * @param pageContext the page context whose response object is assigned
-     * the given locale
+     * @param pageContext the page context whose response object is assigned the given locale
+     *
      * @param locale the response locale
      */
     private static void setResponseLocale(PageContext pc, Locale locale) {
-	// set response locale
-	ServletResponse response = pc.getResponse();
-	response.setLocale(locale);
-	
-	// get response character encoding and store it in session attribute
-	if (pc.getSession() != null) {
+        // set response locale
+        ServletResponse response = pc.getResponse();
+        response.setLocale(locale);
+
+        // get response character encoding and store it in session attribute
+        if (pc.getSession() != null) {
             try {
-	        pc.setAttribute(REQUEST_CHAR_SET,
-			        response.getCharacterEncoding(),
-			        PageContext.SESSION_SCOPE);
-            } catch (IllegalStateException ex) {} // invalidated session ignored
-	}
+                pc.setAttribute(REQUEST_CHAR_SET, response.getCharacterEncoding(), PageContext.SESSION_SCOPE);
+            } catch (IllegalStateException ex) {
+            } // invalidated session ignored
+        }
     }
 
     /**
      * See parseLocale(String, String) for details.
      */
     private static Locale parseLocale(String locale) {
-	return parseLocale(locale, null);
+        return parseLocale(locale, null);
     }
 
     /**
-     * Parses the given locale string into its language and (optionally)
-     * country components, and returns the corresponding
+     * Parses the given locale string into its language and (optionally) country components, and returns the corresponding
      * <tt>java.util.Locale</tt> object.
      *
-     * If the given locale string is null or empty, the runtime's default
-     * locale is returned.
+     * If the given locale string is null or empty, the runtime's default locale is returned.
      *
      * @param locale the locale string to parse
      * @param variant the variant
      *
-     * @return <tt>java.util.Locale</tt> object corresponding to the given
-     * locale string, or the runtime's default locale if the locale string is
-     * null or empty
+     * @return <tt>java.util.Locale</tt> object corresponding to the given locale string, or the runtime's default locale if
+     * the locale string is null or empty
      *
-     * @throws IllegalArgumentException if the given locale does not have a
-     * language component or has an empty country component
+     * @throws IllegalArgumentException if the given locale does not have a language component or has an empty country
+     * component
      */
     private static Locale parseLocale(String locale, String variant) {
 
-	Locale ret = null;
-	String language = locale;
-	String country = null;
-	int index = -1;
+        Locale ret = null;
+        String language = locale;
+        String country = null;
+        int index = -1;
 
-	if (((index = locale.indexOf(HYPHEN)) > -1)
-	        || ((index = locale.indexOf(UNDERSCORE)) > -1)) {
-	    language = locale.substring(0, index);
-	    country = locale.substring(index+1);
-	}
+        if ((index = locale.indexOf(HYPHEN)) > -1 || (index = locale.indexOf(UNDERSCORE)) > -1) {
+            language = locale.substring(0, index);
+            country = locale.substring(index + 1);
+        }
 
-	if ((language == null) || (language.length() == 0)) {
-	    throw new IllegalArgumentException(
-		"Missing language component in 'value' attribute in setLocale");
-	}
+        if (language == null || language.length() == 0) {
+            throw new IllegalArgumentException("Missing language component in 'value' attribute in setLocale");
+        }
 
-	if (country == null) {
-	    if (variant != null)
-		ret = new Locale(language, "", variant);
-	    else
-		ret = new Locale(language, "");
-	} else if (country.length() > 0) {
-	    if (variant != null)
-		ret = new Locale(language, country, variant);
-	    else
-		ret = new Locale(language, country);
-	} else {
-	    throw new IllegalArgumentException(
-		"Empty country component in 'value' attribute in setLocale");
-	}
+        if (country == null) {
+            if (variant != null) {
+                ret = new Locale(language, "", variant);
+            } else {
+                ret = new Locale(language, "");
+            }
+        } else if (country.length() > 0) {
+            if (variant != null) {
+                ret = new Locale(language, country, variant);
+            } else {
+                ret = new Locale(language, country);
+            }
+        } else {
+            throw new IllegalArgumentException("Empty country component in 'value' attribute in setLocale");
+        }
 
-	return ret;
+        return ret;
     }
 
     /**
-     * HttpServletRequest.getLocales() returns the server's default locale 
-     * if the request did not specify a preferred language.
-     * We do not want this behavior, because it prevents us from using
-     * the fallback locale. 
-     * We therefore need to return an empty Enumeration if no preferred 
-     * locale has been specified. This way, the logic for the fallback 
-     * locale will be able to kick in.
+     * HttpServletRequest.getLocales() returns the server's default locale if the request did not specify a preferred
+     * language. We do not want this behavior, because it prevents us from using the fallback locale. We therefore need to
+     * return an empty Enumeration if no preferred locale has been specified. This way, the logic for the fallback locale
+     * will be able to kick in.
      */
-    private static Enumeration getRequestLocales(HttpServletRequest request) {        
+    private static Enumeration getRequestLocales(HttpServletRequest request) {
         Enumeration values = request.getHeaders("accept-language");
         if (values.hasMoreElements()) {
             // At least one "accept-language". Simply return
@@ -528,4 +450,3 @@ public class LocaleSupport {
     }
 
 }
-

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/fmt/LocalizationContext.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/fmt/LocalizationContext.java
@@ -23,17 +23,17 @@ import java.util.ResourceBundle;
 /**
  * Class representing an I18N localization context.
  *
- * <p> An I18N localization context has two components: a resource bundle and
- * the locale that led to the resource bundle match.
+ * <p>
+ * An I18N localization context has two components: a resource bundle and the locale that led to the resource bundle
+ * match.
  *
- * <p> The resource bundle component is used by &lt;fmt:message&gt; for mapping
- * message keys to localized messages, and the locale component is used by the
- * &lt;fmt:message&gt;, &lt;fmt:formatNumber&gt;, &lt;fmt:parseNumber&gt;, &lt;fmt:formatDate&gt;,
- * and &lt;fmt:parseDate&gt; actions as their formatting or parsing locale, respectively.
+ * <p>
+ * The resource bundle component is used by &lt;fmt:message&gt; for mapping message keys to localized messages, and the
+ * locale component is used by the &lt;fmt:message&gt;, &lt;fmt:formatNumber&gt;, &lt;fmt:parseNumber&gt;,
+ * &lt;fmt:formatDate&gt;, and &lt;fmt:parseDate&gt; actions as their formatting or parsing locale, respectively.
  *
  * @author Jan Luehe
  */
-
 public class LocalizationContext {
 
     // the localization context's resource bundle
@@ -46,57 +46,53 @@ public class LocalizationContext {
      * Constructs an empty I18N localization context.
      */
     public LocalizationContext() {
-	bundle = null;
-	locale = null;
+        bundle = null;
+        locale = null;
     }
 
     /**
-     * Constructs an I18N localization context from the given resource bundle
-     * and locale.
+     * Constructs an I18N localization context from the given resource bundle and locale.
      *
-     * <p> The specified locale is the application- or browser-based preferred
-     * locale that led to the resource bundle match.
+     * <p>
+     * The specified locale is the application- or browser-based preferred locale that led to the resource bundle match.
      *
      * @param bundle The localization context's resource bundle
      * @param locale The localization context's locale
      */
     public LocalizationContext(ResourceBundle bundle, Locale locale) {
-	this.bundle = bundle;
-	this.locale = locale;
+        this.bundle = bundle;
+        this.locale = locale;
     }
 
     /**
      * Constructs an I18N localization context from the given resource bundle.
      *
-     * <p> The localization context's locale is taken from the given
-     * resource bundle.
+     * <p>
+     * The localization context's locale is taken from the given resource bundle.
      *
      * @param bundle The resource bundle
      */
     public LocalizationContext(ResourceBundle bundle) {
-	this.bundle = bundle;
-	this.locale = bundle.getLocale();
+        this.bundle = bundle;
+        this.locale = bundle.getLocale();
     }
 
-    /** 
+    /**
      * Gets the resource bundle of this I18N localization context.
-     * 
-     * @return The resource bundle of this I18N localization context, or null
-     * if this I18N localization context is empty
-     */ 
+     *
+     * @return The resource bundle of this I18N localization context, or null if this I18N localization context is empty
+     */
     public ResourceBundle getResourceBundle() {
-	return bundle;
+        return bundle;
     }
 
-    /** 
+    /**
      * Gets the locale of this I18N localization context.
      *
-     * @return The locale of this I18N localization context, or null if this
-     * I18N localization context is empty, or its resource bundle is a
-     * (locale-less) root resource bundle.
-     */ 
+     * @return The locale of this I18N localization context, or null if this I18N localization context is empty, or its
+     * resource bundle is a (locale-less) root resource bundle.
+     */
     public Locale getLocale() {
-	return locale;
+        return locale;
     }
 }
-

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/sql/Result.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/sql/Result.java
@@ -20,21 +20,21 @@ package jakarta.servlet.jsp.jstl.sql;
 import java.util.SortedMap;
 
 /**
- * <p>This interface represents the result of a &lt;sql:query&gt;
- * action. It provides access to the following information in the
- * query result:</p>
+ * <p>
+ * This interface represents the result of a &lt;sql:query&gt; action. It provides access to the following information
+ * in the query result:
+ * </p>
  *
  * <ul>
- * <li> The result rows (<tt>getRows()</tt> and <tt>getRowsByIndex()</tt>)
- * <li> The column names (<tt>getColumnNames()</tt>)
- * <li> The number of rows in the result (<tt>getRowCount()</tt>)
- * <li> An indication whether the rows returned represent the complete result 
- *      or just a subset that is limited by a maximum row setting
- *      (<tt>isLimitedByMaxRows()</tt>)
+ * <li>The result rows (<tt>getRows()</tt> and <tt>getRowsByIndex()</tt>)
+ * <li>The column names (<tt>getColumnNames()</tt>)
+ * <li>The number of rows in the result (<tt>getRowCount()</tt>)
+ * <li>An indication whether the rows returned represent the complete result or just a subset that is limited by a
+ * maximum row setting (<tt>isLimitedByMaxRows()</tt>)
  * </ul>
  *
- * <p>An implementation of the <tt>Result</tt> interface provides a
- * <i>disconnected</i> view into the result of a query.
+ * <p>
+ * An implementation of the <tt>Result</tt> interface provides a <i>disconnected</i> view into the result of a query.
  *
  * @author Justyna Horwat
  *
@@ -42,56 +42,57 @@ import java.util.SortedMap;
 public interface Result {
 
     /**
-     * <p>Returns the result of the query as an array of <code>SortedMap</code> objects. 
-     * Each item of the array represents a specific row in the query result.</p>
+     * <p>
+     * Returns the result of the query as an array of <code>SortedMap</code> objects. Each item of the array represents a
+     * specific row in the query result.
+     * </p>
      *
-     * <p>A row is structured as a <code>SortedMap</code> object where the key is the column name, 
-     * and where the value is the value associated with the column identified by 
-     * the key. The column value is an Object of the Java type corresponding 
-     * to the mapping between column types and Java types defined by the JDBC 
-     * specification when the <code>ResultSet.getObject()</code> method is used.</p>
+     * <p>
+     * A row is structured as a <code>SortedMap</code> object where the key is the column name, and where the value is the
+     * value associated with the column identified by the key. The column value is an Object of the Java type corresponding
+     * to the mapping between column types and Java types defined by the JDBC specification when the
+     * <code>ResultSet.getObject()</code> method is used.
+     * </p>
      *
-     * <p>The <code>SortedMap</code> must use the <code>Comparator</code> 
-     * <code>java.util.String.CASE_INSENSITIVE_ORDER</code>. 
-     * This makes it possible to access the key as a case insensitive representation 
-     * of a column name. This method will therefore work regardless of the case of 
-     * the column name returned by the database.</p>
+     * <p>
+     * The <code>SortedMap</code> must use the <code>Comparator</code> <code>java.util.String.CASE_INSENSITIVE_ORDER</code>.
+     * This makes it possible to access the key as a case insensitive representation of a column name. This method will
+     * therefore work regardless of the case of the column name returned by the database.
+     * </p>
      *
      * @return The result rows as an array of <code>SortedMap</code> objects
      */
-    public SortedMap[] getRows();
+    SortedMap[] getRows();
 
     /**
-     * Returns the result of the query as an array of arrays. 
-     * The first array dimension represents a specific row in the query result. 
-     * The array elements for each row are Object instances of the Java type 
-     * corresponding to the mapping between column types and Java types defined 
-     * by the JDBC specification when the <code>ResultSet.getObject()</code> method is used.
+     * Returns the result of the query as an array of arrays. The first array dimension represents a specific row in the
+     * query result. The array elements for each row are Object instances of the Java type corresponding to the mapping
+     * between column types and Java types defined by the JDBC specification when the <code>ResultSet.getObject()</code>
+     * method is used.
      *
      * @return the result rows as an array of <code>Object[]</code> objects
      */
-    public Object[][] getRowsByIndex();
+    Object[][] getRowsByIndex();
 
     /**
-     * Returns the names of the columns in the result. The order of the names in the array 
-     * matches the order in which columns are returned in method getRowsByIndex().
+     * Returns the names of the columns in the result. The order of the names in the array matches the order in which
+     * columns are returned in method getRowsByIndex().
      *
      * @return the column names as an array of <code>String</code> objects
      */
-    public String[] getColumnNames();
+    String[] getColumnNames();
 
     /**
      * Returns the number of rows in the cached ResultSet
      *
      * @return the number of rows in the result
      */
-    public int getRowCount();
+    int getRowCount();
 
     /**
      * Returns true if the query was limited by a maximum row setting
      *
-     * @return <tt>true</tt> if the query was limited by a maximum
-     * row setting
+     * @return <tt>true</tt> if the query was limited by a maximum row setting
      */
-    public boolean isLimitedByMaxRows();
+    boolean isLimitedByMaxRows();
 }

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/sql/ResultImpl.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/sql/ResultImpl.java
@@ -27,12 +27,11 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 
 /**
- * <p>This class creates a cached version of a <tt>ResultSet</tt>.
- * It's represented as a <tt>Result</tt> implementation, capable of 
- * returing an array of <tt>Row</tt> objects containing a <tt>Column</tt> 
- * instance for each column in the row.   It is not part of the Jakarta Standard Tab Library
- * API; it serves merely as a back-end to ResultSupport's static methods.
- * Thus, we scope its access to the package.
+ * <p>
+ * This class creates a cached version of a <tt>ResultSet</tt>. It's represented as a <tt>Result</tt> implementation,
+ * capable of returing an array of <tt>Row</tt> objects containing a <tt>Column</tt> instance for each column in the
+ * row. It is not part of the Jakarta Standard Tab Library API; it serves merely as a back-end to ResultSupport's static
+ * methods. Thus, we scope its access to the package.
  *
  * @author Hans Bergsten
  * @author Justyna Horwat
@@ -45,56 +44,50 @@ class ResultImpl implements Result, Serializable {
     private boolean isLimited;
 
     /**
-     * This constructor reads the ResultSet and saves a cached
-     * copy.
-     * It's important to note that this object will be serializable only
-     * if the objects returned by the ResultSet are serializable too.
+     * This constructor reads the ResultSet and saves a cached copy. It's important to note that this object will be
+     * serializable only if the objects returned by the ResultSet are serializable too.
      *
-     * @param rs an open <tt>ResultSet</tt>, positioned before the first
-     * row
+     * @param resultSet an open <tt>ResultSet</tt>, positioned before the first row
      * @param startRow beginning row to be cached
      * @param maxRows query maximum rows limit
      * @exception java.sql.SQLException if a database error occurs
      */
-    public ResultImpl(ResultSet rs, int startRow, int maxRows)
-        throws SQLException 
-    {
-        rowMap = new ArrayList<SortedMap<String, Object>>();
-        rowByIndex = new ArrayList<Object[]>();
+    public ResultImpl(ResultSet resultSet, int startRow, int maxRows) throws SQLException {
+        rowMap = new ArrayList<>();
+        rowByIndex = new ArrayList<>();
 
-        ResultSetMetaData rsmd = rs.getMetaData();
-        int noOfColumns = rsmd.getColumnCount();
+        ResultSetMetaData resultSetMetaData = resultSet.getMetaData();
+        int noOfColumns = resultSetMetaData.getColumnCount();
 
         // Create the column name array
         columnNames = new String[noOfColumns];
         for (int i = 1; i <= noOfColumns; i++) {
-            columnNames[i-1] = rsmd.getColumnName(i);
+            columnNames[i - 1] = resultSetMetaData.getColumnName(i);
         }
 
         // Throw away all rows upto startRow
         for (int i = 0; i < startRow; i++) {
-            rs.next();
+            resultSet.next();
         }
 
         // Process the remaining rows upto maxRows
         int processedRows = 0;
-        while (rs.next()) {
-            if ((maxRows != -1) && (processedRows == maxRows)) {
-                isLimited = true; 
+        while (resultSet.next()) {
+            if (maxRows != -1 && processedRows == maxRows) {
+                isLimited = true;
                 break;
             }
             Object[] columns = new Object[noOfColumns];
-            SortedMap<String, Object> columnMap = 
-                new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
+            SortedMap<String, Object> columnMap = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
             // JDBC uses 1 as the lowest index!
             for (int i = 1; i <= noOfColumns; i++) {
-                Object value =  rs.getObject(i);
-                if (rs.wasNull()) {
+                Object value = resultSet.getObject(i);
+                if (resultSet.wasNull()) {
                     value = null;
                 }
-                columns[i-1] = value;
-                columnMap.put(columnNames[i-1], value);
+                columns[i - 1] = value;
+                columnMap.put(columnNames[i - 1], value);
             }
             rowMap.add(columnMap);
             rowByIndex.add(columns);
@@ -103,47 +96,45 @@ class ResultImpl implements Result, Serializable {
     }
 
     /**
-     * Returns an array of SortedMap objects. The SortedMap
-     * object key is the ColumnName and the value is the ColumnValue.
-     * SortedMap was created using the CASE_INSENSITIVE_ORDER
-     * Comparator so the key is the case insensitive representation
+     * Returns an array of SortedMap objects. The SortedMap object key is the ColumnName and the value is the ColumnValue.
+     * SortedMap was created using the CASE_INSENSITIVE_ORDER Comparator so the key is the case insensitive representation
      * of the ColumnName.
      *
      * @return an array of Map, or null if there are no rows
      */
+    @Override
     public SortedMap[] getRows() {
         if (rowMap == null) {
             return null;
         }
 
-        //should just be able to return SortedMap[] object
+        // should just be able to return SortedMap[] object
         return rowMap.toArray(new SortedMap[0]);
     }
 
-
     /**
-     * Returns an array of Object[] objects. The first index
-     * designates the Row, the second the Column. The array
-     * stores the value at the specified row and column.
+     * Returns an array of Object[] objects. The first index designates the Row, the second the Column. The array stores the
+     * value at the specified row and column.
      *
      * @return an array of Object[], or null if there are no rows
      */
+    @Override
     public Object[][] getRowsByIndex() {
         if (rowByIndex == null) {
             return null;
         }
 
-        //should just be able to return Object[][] object
-        return (Object [][])rowByIndex.toArray(new Object[0][0]);
+        // should just be able to return Object[][] object
+        return rowByIndex.toArray(new Object[0][0]);
     }
 
     /**
-     * Returns an array of String objects. The array represents
-     * the names of the columns arranged in the same order as in
+     * Returns an array of String objects. The array represents the names of the columns arranged in the same order as in
      * the getRowsByIndex() method.
      *
      * @return an array of String[]
      */
+    @Override
     public String[] getColumnNames() {
         return columnNames;
     }
@@ -151,9 +142,9 @@ class ResultImpl implements Result, Serializable {
     /**
      * Returns the number of rows in the cached ResultSet
      *
-     * @return the number of cached rows, or -1 if the Result could
-     *    not be initialized due to SQLExceptions
+     * @return the number of cached rows, or -1 if the Result could not be initialized due to SQLExceptions
      */
+    @Override
     public int getRowCount() {
         if (rowMap == null) {
             return -1;
@@ -166,6 +157,7 @@ class ResultImpl implements Result, Serializable {
      *
      * @return true if the query was limited by a MaxRows attribute
      */
+    @Override
     public boolean isLimitedByMaxRows() {
         return isLimited;
     }

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/sql/ResultSupport.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/sql/ResultSupport.java
@@ -21,16 +21,15 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 /**
- * <p>Supports the creation of a jakarta.servlet.jsp.jstl.sql.Result object
- * from a source java.sql.ResultSet object. A Result object makes it much 
- * easier for page authors to access and manipulate the data resulting 
- * from a SQL query.</p>
+ * <p>
+ * Supports the creation of a jakarta.servlet.jsp.jstl.sql.Result object from a source java.sql.ResultSet object. A
+ * Result object makes it much easier for page authors to access and manipulate the data resulting from a SQL query.
+ * </p>
  *
  * @author Justyna Horwat
  *
  */
 public class ResultSupport {
-
 
     /**
      * Converts a <code>ResultSet</code> object to a <code>Result</code> object.
@@ -48,14 +47,12 @@ public class ResultSupport {
     }
 
     /**
-     * Converts <code>maxRows</code> of a <code>ResultSet</code> object to a 
-     * <code>Result</code> object.
+     * Converts <code>maxRows</code> of a <code>ResultSet</code> object to a <code>Result</code> object.
      *
      * @param rs the <code>ResultSet</code> object
      * @param maxRows the maximum number of rows to be cached into the <code>Result</code> object.
      *
-     * @return The <code>Result</code> object created from the <code>ResultSet</code>,
-     * limited by <code>maxRows</code>
+     * @return The <code>Result</code> object created from the <code>ResultSet</code>, limited by <code>maxRows</code>
      */
     public static Result toResult(ResultSet rs, int maxRows) {
         try {

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/sql/SQLExecutionTag.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/sql/SQLExecutionTag.java
@@ -18,43 +18,44 @@
 package jakarta.servlet.jsp.jstl.sql;
 
 /**
- * <p>This interface allows tag handlers implementing it to receive
- * values for parameter markers in their SQL statements.</p>
+ * <p>
+ * This interface allows tag handlers implementing it to receive values for parameter markers in their SQL statements.
+ * </p>
  *
- * <p>This interface is implemented by both &lt;sql:query&gt; and
- * &lt;sql:update&gt;. Its <code>addSQLParameter()</code> method
- * is called by nested parameter actions (such as &lt;sql:param&gt;)
- * to substitute <code>PreparedStatement</code> parameter values for
- * "?" parameter markers in the SQL statement of the enclosing
- * <code>SQLExecutionTag</code> action.</p>
+ * <p>
+ * This interface is implemented by both &lt;sql:query&gt; and &lt;sql:update&gt;. Its <code>addSQLParameter()</code>
+ * method is called by nested parameter actions (such as &lt;sql:param&gt;) to substitute <code>PreparedStatement</code>
+ * parameter values for "?" parameter markers in the SQL statement of the enclosing <code>SQLExecutionTag</code> action.
+ * </p>
  *
- * <p>The given parameter values are converted to their corresponding
- * SQL type (following the rules in the JDBC specification) before
- * they are sent to the database.</p>
+ * <p>
+ * The given parameter values are converted to their corresponding SQL type (following the rules in the JDBC
+ * specification) before they are sent to the database.
+ * </p>
  *
- * <p>Keeping track of the index of the parameter values being added
- * is the responsibility of the tag handler implementing this
- * interface</p>
+ * <p>
+ * Keeping track of the index of the parameter values being added is the responsibility of the tag handler implementing
+ * this interface
+ * </p>
  *
- * <p>The <code>SQLExcecutionTag</code> interface is exposed in order
- * to support custom parameter actions which may retrieve their
- * parameters from any source and process them before substituting
- * them for a parameter marker in the SQL statement of the
- * enclosing <code>SQLExecutionTag</code> action</p>
+ * <p>
+ * The <code>SQLExcecutionTag</code> interface is exposed in order to support custom parameter actions which may
+ * retrieve their parameters from any source and process them before substituting them for a parameter marker in the SQL
+ * statement of the enclosing <code>SQLExecutionTag</code> action
+ * </p>
  *
  * @author Justyna Horwat
  */
 public interface SQLExecutionTag {
 
     /**
-     * Adds a PreparedStatement parameter value. 
-     * Must behave as if it calls <code>PreparedStatement.setObject(int, Object)</code>. 
-     * For each tag invocation, the integral index passed logically to <code>setObject()</code> 
-     * must begin with 1 and must be incremented by 1 for each subsequent invocation 
-     * of <code>addSQLParameter()</code>. The Object logically passed to <code>setObject()</code> must be the 
-     * unmodified object received in the value argument.
+     * Adds a PreparedStatement parameter value. Must behave as if it calls
+     * <code>PreparedStatement.setObject(int, Object)</code>. For each tag invocation, the integral index passed logically
+     * to <code>setObject()</code> must begin with 1 and must be incremented by 1 for each subsequent invocation of
+     * <code>addSQLParameter()</code>. The Object logically passed to <code>setObject()</code> must be the unmodified object
+     * received in the value argument.
      *
      * @param value the <code>PreparedStatement</code> parameter value
      */
-    public void addSQLParameter(Object value);
+    void addSQLParameter(Object value);
 }

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/PermittedTaglibsTLV.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/PermittedTaglibsTLV.java
@@ -22,9 +22,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.StringTokenizer;
 
-import jakarta.servlet.jsp.tagext.PageData;
-import jakarta.servlet.jsp.tagext.TagLibraryValidator;
-import jakarta.servlet.jsp.tagext.ValidationMessage;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -33,23 +30,30 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
+import jakarta.servlet.jsp.tagext.PageData;
+import jakarta.servlet.jsp.tagext.TagLibraryValidator;
+import jakarta.servlet.jsp.tagext.ValidationMessage;
+
 /**
- * <p>A TagLibraryValidator class to allow a TLD to restrict what
- * taglibs (in addition to itself) may be imported on a page where it's
- * used.</p>
+ * <p>
+ * A TagLibraryValidator class to allow a TLD to restrict what taglibs (in addition to itself) may be imported on a page
+ * where it's used.
+ * </p>
  *
- * <p>This TLV supports the following initialization parameter:</p>
+ * <p>
+ * This TLV supports the following initialization parameter:
+ * </p>
  * <ul>
- * <li><b>permittedTaglibs</b>: A whitespace-separated list of URIs corresponding 
- *   to tag libraries permitted to be imported on the page in addition to the tag 
- *   library that references PermittedTaglibsTLV (which is allowed implicitly).
+ * <li><b>permittedTaglibs</b>: A whitespace-separated list of URIs corresponding to tag libraries permitted to be
+ * imported on the page in addition to the tag library that references PermittedTaglibsTLV (which is allowed
+ * implicitly).
  * </ul>
  *
  * @author Shawn Bayern
  */
 public class PermittedTaglibsTLV extends TagLibraryValidator {
 
-    //*********************************************************************
+    // *********************************************************************
     // Constants
 
     // parameter names
@@ -64,133 +68,131 @@ public class PermittedTaglibsTLV extends TagLibraryValidator {
     // QName for "<jsp:root>" element
     private final String JSP_ROOT_QN = "jsp:root";
 
-
-    //*********************************************************************
+    // *********************************************************************
     // Validation and configuration state (protected)
 
-    private Set<String> permittedTaglibs;		// what URIs are allowed?
-    private boolean failed;			// did the page fail?
-    private String uri;				// our taglib's URI
+    private Set<String> permittedTaglibs; // what URIs are allowed?
+    private boolean failed; // did the page fail?
+    private String uri; // our taglib's URI
 
-    //*********************************************************************
+    // *********************************************************************
     // Constructor and lifecycle management
 
     public PermittedTaglibsTLV() {
-	super();
-	init();
+        super();
+        init();
     }
 
     private void init() {
-	permittedTaglibs = null;
+        permittedTaglibs = null;
         failed = false;
     }
 
+    @Override
     public void release() {
-	super.release();
-	init();
+        super.release();
+        init();
     }
-    
 
-    //*********************************************************************
+    // *********************************************************************
     // Validation entry point
 
-    public synchronized ValidationMessage[] validate(
-	    String prefix, String uri, PageData page) {
-	try {
+    @Override
+    public synchronized ValidationMessage[] validate(String prefix, String uri, PageData page) {
+        try {
 
-	    // initialize
-	    this.uri = uri;
-	    permittedTaglibs = readConfiguration();
+            // initialize
+            this.uri = uri;
+            permittedTaglibs = readConfiguration();
 
-	    // get a handler
-	    DefaultHandler h = new PermittedTaglibsHandler();
+            // get a handler
+            DefaultHandler handler = new PermittedTaglibsHandler();
 
-	    // parse the page
-	    SAXParserFactory f = SAXParserFactory.newInstance();
-	    f.setValidating(true);
-	    SAXParser p = f.newSAXParser();
-	    p.parse(page.getInputStream(), h);
+            // parse the page
+            SAXParserFactory parserFactory = SAXParserFactory.newInstance();
+            parserFactory.setValidating(true);
+            SAXParser parser = parserFactory.newSAXParser();
+            parser.parse(page.getInputStream(), handler);
 
-	    if (failed)
-		return vmFromString(
-		    "taglib " + prefix + " (" + uri + ") allows only the "
-		    + "following taglibs to be imported: " + permittedTaglibs);
-	    else
-		return null;
+            if (failed) {
+                return vmFromString("taglib " + prefix + " (" + uri + ") allows only the " + "following taglibs to be imported: " + permittedTaglibs);
+            } else {
+                return null;
+            }
 
-	} catch (SAXException ex) {
-	    return vmFromString(ex.toString());
-	} catch (ParserConfigurationException ex) {
-	    return vmFromString(ex.toString());
-	} catch (IOException ex) {
-	    return vmFromString(ex.toString());
-	}
+        } catch (SAXException ex) {
+            return vmFromString(ex.toString());
+        } catch (ParserConfigurationException ex) {
+            return vmFromString(ex.toString());
+        } catch (IOException ex) {
+            return vmFromString(ex.toString());
+        }
     }
 
-
-    //*********************************************************************
+    // *********************************************************************
     // Utility functions
 
     /** Returns Set of permitted taglibs, based on configuration data. */
     private Set<String> readConfiguration() {
 
-	// initialize the Set
-	Set<String> s = new HashSet<String>();
+        // initialize the Set
+        Set<String> s = new HashSet<>();
 
-	// get the space-separated list of taglibs
-	String uris = (String) getInitParameters().get(PERMITTED_TAGLIBS_PARAM);
+        // get the space-separated list of taglibs
+        String uris = (String) getInitParameters().get(PERMITTED_TAGLIBS_PARAM);
 
         // separate the list into individual uris and store them
         StringTokenizer st = new StringTokenizer(uris);
-        while (st.hasMoreTokens())
-	    s.add(st.nextToken());
+        while (st.hasMoreTokens()) {
+            s.add(st.nextToken());
+        }
 
-	// return the new Set
-	return s;
+        // return the new Set
+        return s;
 
     }
 
     // constructs a ValidationMessage[] from a single String and no ID
     private ValidationMessage[] vmFromString(String message) {
-	return new ValidationMessage[] {
-	    new ValidationMessage(null, message)
-	};
+        return new ValidationMessage[] { new ValidationMessage(null, message) };
     }
 
-
-    //*********************************************************************
+    // *********************************************************************
     // SAX handler
 
     /** The handler that provides the base of our implementation. */
     private class PermittedTaglibsHandler extends DefaultHandler {
 
         // if the element is <jsp:root>, check its "xmlns:" attributes
-        public void startElement(
-                String ns, String ln, String qn, Attributes a) {
+        @Override
+        public void startElement(String ns, String ln, String qn, Attributes a) {
 
-	    // ignore all but <jsp:root>
-	    if (!qn.equals(JSP_ROOT_QN) &&
-	            (!ns.equals(JSP_ROOT_URI) || !ln.equals(JSP_ROOT_NAME)))
-		return;
+            // ignore all but <jsp:root>
+            if (!qn.equals(JSP_ROOT_QN) && (!ns.equals(JSP_ROOT_URI) || !ln.equals(JSP_ROOT_NAME))) {
+                return;
+            }
 
-	    // for <jsp:root>, check the attributes
-	    for (int i = 0; i < a.getLength(); i++) {
-		String name = a.getQName(i);
+            // for <jsp:root>, check the attributes
+            for (int i = 0; i < a.getLength(); i++) {
+                String name = a.getQName(i);
 
-		// ignore non-namespace attributes, and xmlns:jsp
-		if (!name.startsWith("xmlns:") || name.equals("xmlns:jsp"))
-		    continue;
+                // ignore non-namespace attributes, and xmlns:jsp
+                if (!name.startsWith("xmlns:") || name.equals("xmlns:jsp")) {
+                    continue;
+                }
 
-		String value = a.getValue(i);
-		// ignore our own namespace declaration
-		if (value.equals(uri))
-		    continue;
+                String value = a.getValue(i);
+                // ignore our own namespace declaration
+                if (value.equals(uri)) {
+                    continue;
+                }
 
-		// otherwise, ensure that 'value' is in 'permittedTaglibs' set
-		if (!permittedTaglibs.contains(value))
-		    failed = true;
-	    }
-	}
+                // otherwise, ensure that 'value' is in 'permittedTaglibs' set
+                if (!permittedTaglibs.contains(value)) {
+                    failed = true;
+                }
+            }
+        }
     }
 
 }

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/ScriptFreeTLV.java
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/ScriptFreeTLV.java
@@ -21,9 +21,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
 
-import jakarta.servlet.jsp.tagext.PageData;
-import jakarta.servlet.jsp.tagext.TagLibraryValidator;
-import jakarta.servlet.jsp.tagext.ValidationMessage;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -32,215 +29,215 @@ import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
 
+import jakarta.servlet.jsp.tagext.PageData;
+import jakarta.servlet.jsp.tagext.TagLibraryValidator;
+import jakarta.servlet.jsp.tagext.ValidationMessage;
+
 /**
- * <p>A TagLibraryValidator for enforcing restrictions against
- * the use of JSP scripting elements.</p>
- * <p>This TLV supports four initialization parameters, for controlling
- * which of the four types of scripting elements are allowed or prohibited:</p>
+ * <p>
+ * A TagLibraryValidator for enforcing restrictions against the use of JSP scripting elements.
+ * </p>
+ * <p>
+ * This TLV supports four initialization parameters, for controlling which of the four types of scripting elements are
+ * allowed or prohibited:
+ * </p>
  * <ul>
- * <li><b>allowDeclarations</b>: if true, indicates that declaration elements
- * are not prohibited.
- * <li><b>allowScriptlets</b>: if true, indicates that scriptlets are not
- * prohibited
- * <li><b>allowExpressions</b>: if true, indicates that top-level expression
- * elements (i.e., expressions not associated with request-time attribute
- * values) are not prohibited.
- * <li><b>allowRTExpressions</b>: if true, indicates that expression elements
- * associated with request-time attribute values are not prohibited.
+ * <li><b>allowDeclarations</b>: if true, indicates that declaration elements are not prohibited.
+ * <li><b>allowScriptlets</b>: if true, indicates that scriptlets are not prohibited
+ * <li><b>allowExpressions</b>: if true, indicates that top-level expression elements (i.e., expressions not associated
+ * with request-time attribute values) are not prohibited.
+ * <li><b>allowRTExpressions</b>: if true, indicates that expression elements associated with request-time attribute
+ * values are not prohibited.
  * </ul>
- * <p>The default value for all for initialization parameters is false,
- * indicating all forms of scripting elements are to be prohibited.</p>
- * 
+ * <p>
+ * The default value for all for initialization parameters is false, indicating all forms of scripting elements are to
+ * be prohibited.
+ * </p>
+ *
  * @author <a href="mailto:mak@taglib.com">Mark A. Kolb</a>
  * @author Shawn Bayern (minor changes)
  */
 public class ScriptFreeTLV extends TagLibraryValidator {
-  private boolean allowDeclarations = false;
-  private boolean allowScriptlets = false;
-  private boolean allowExpressions = false;
-  private boolean allowRTExpressions = false;
-  private SAXParserFactory factory;
+    private boolean allowDeclarations = false;
+    private boolean allowScriptlets = false;
+    private boolean allowExpressions = false;
+    private boolean allowRTExpressions = false;
+    private SAXParserFactory factory;
 
-  /**
-   * Constructs a new validator instance.
-   * Initializes the parser factory to create non-validating, namespace-aware
-   * SAX parsers.
-   */
-  public ScriptFreeTLV () {
-    factory = SAXParserFactory.newInstance();
-    factory.setValidating(false);
-    factory.setNamespaceAware(true);
-  }
-
-  /**
-   * Sets the values of the initialization parameters, as supplied in the TLD.
-   * @param initParms a mapping from the names of the initialization parameters
-   * to their values, as specified in the TLD.
-   */
-  public void setInitParameters (Map<String, Object> initParms) {
-    super.setInitParameters(initParms);
-    String declarationsParm = (String) initParms.get("allowDeclarations");
-    String scriptletsParm = (String) initParms.get("allowScriptlets");
-    String expressionsParm = (String) initParms.get("allowExpressions");
-    String rtExpressionsParm = (String) initParms.get("allowRTExpressions");
-
-    allowDeclarations = "true".equalsIgnoreCase(declarationsParm);
-    allowScriptlets = "true".equalsIgnoreCase(scriptletsParm);
-    allowExpressions = "true".equalsIgnoreCase(expressionsParm);
-    allowRTExpressions = "true".equalsIgnoreCase(rtExpressionsParm);
-  }
-
-  /**
-   * Validates a single JSP page.
-   * @param prefix the namespace prefix specified by the page for the
-   * custom tag library being validated.
-   * @param uri the URI specified by the page for the TLD of the
-   * custom tag library being validated.
-   * @param page a wrapper around the XML representation of the page
-   * being validated.
-   * @return null, if the page is valid; otherwise, a ValidationMessage[]
-   * containing one or more messages indicating why the page is not valid.
-   */
-  public ValidationMessage[] validate
-      (String prefix, String uri, PageData page) {
-    InputStream in = null;
-    SAXParser parser;
-    MyContentHandler handler = new MyContentHandler();
-    try {
-      synchronized (factory) {
-	parser = factory.newSAXParser();
-      }
-      in = page.getInputStream();
-      parser.parse(in, handler);
-    }
-    catch (ParserConfigurationException e) {
-      return vmFromString(e.toString());
-    }
-    catch (SAXException e) {
-      return vmFromString(e.toString());
-    }
-    catch (IOException e) {
-      return vmFromString(e.toString());
-    }
-    finally {
-      if (in != null) try { in.close(); } catch (IOException e) {}
-    }
-    return handler.reportResults();
-  }
-
-  /** 
-   * Handler for SAX events. 
-   * Four counters are provided as instance variables,
-   * for counting occurrences of prohibited scripting elements.
-   */
-  private class MyContentHandler extends DefaultHandler {
-    private int declarationCount = 0;
-    private int scriptletCount = 0;
-    private int expressionCount = 0;
-    private int rtExpressionCount = 0;
-
-    /** 
-     * This event is received whenever a new element is encountered.
-     * The qualified name of each such element is compared against
-     * the names of any prohibited scripting elements. When found, the
-     * corresponding counter is incremented.
-     * If expressions representing request-time attribute values are
-     * prohibited, it is also necessary to check the values of all
-     * attributes specified by the element. (Trying to figure out
-     * which attributes actually support request-time attribute values
-     * and checking only those is far more trouble than it's worth.)
+    /**
+     * Constructs a new validator instance. Initializes the parser factory to create non-validating, namespace-aware SAX
+     * parsers.
      */
-    public void startElement (String namespaceUri, 
-			      String localName, String qualifiedName,
-			      Attributes atts) {
-      if ((! allowDeclarations)
-	  && qualifiedName.equals("jsp:declaration"))
-	++declarationCount;
-      else if ((! allowScriptlets)
-	       && qualifiedName.equals("jsp:scriptlet"))
-	++scriptletCount;
-      else if ((! allowExpressions)
-	       && qualifiedName.equals("jsp:expression"))
-	++expressionCount;
-      if (! allowRTExpressions) countRTExpressions(atts);
+    public ScriptFreeTLV() {
+        factory = SAXParserFactory.newInstance();
+        factory.setValidating(false);
+        factory.setNamespaceAware(true);
     }
 
     /**
-     * Auxiliary method for checking attribute values to see if
-     * are specified via request-time attribute values.
-     * Expressions representing request-time attribute values are
-     * recognized by their "%=" and "%" delimiters. When found, the
-     * corresponding counter is incremented.
+     * Sets the values of the initialization parameters, as supplied in the TLD.
+     *
+     * @param initParms a mapping from the names of the initialization parameters to their values, as specified in the TLD.
      */
-    private void countRTExpressions (Attributes atts) {
-      int stop = atts.getLength();
-      for (int i = 0; i < stop; ++i) {
-	String attval = atts.getValue(i);
-	if (attval.startsWith("%=") && attval.endsWith("%"))
-	  ++rtExpressionCount;
-      }
+    public void setInitParameters(Map<String, Object> initParms) {
+        super.setInitParameters(initParms);
+        String declarationsParm = (String) initParms.get("allowDeclarations");
+        String scriptletsParm = (String) initParms.get("allowScriptlets");
+        String expressionsParm = (String) initParms.get("allowExpressions");
+        String rtExpressionsParm = (String) initParms.get("allowRTExpressions");
+
+        allowDeclarations = "true".equalsIgnoreCase(declarationsParm);
+        allowScriptlets = "true".equalsIgnoreCase(scriptletsParm);
+        allowExpressions = "true".equalsIgnoreCase(expressionsParm);
+        allowRTExpressions = "true".equalsIgnoreCase(rtExpressionsParm);
     }
 
     /**
-     * Constructs a String reporting the number(s) of prohibited
-     * scripting elements that were detected, if any.
-     * Returns null if no violations were found, making the result
-     * of this method suitable for the return value of the
-     * TagLibraryValidator.validate() method.
-     * 
-     * TODO:  The update from 7/13/2001 merely makes this validator
-     * compliant with the new TLV API, but does not fully take advantage
-     * of this API.  In the future, we should do so... but because
-     * of the possibility that anti-script checking will be incorporated
-     * into the base TLV, I've held off for now and just changed this
-     * class to use the new API.  -- SB.
+     * Validates a single JSP page.
+     *
+     * @param prefix the namespace prefix specified by the page for the custom tag library being validated.
+     * @param uri the URI specified by the page for the TLD of the custom tag library being validated.
+     * @param page a wrapper around the XML representation of the page being validated.
+     * @return null, if the page is valid; otherwise, a ValidationMessage[] containing one or more messages indicating why
+     * the page is not valid.
      */
-    public ValidationMessage[] reportResults () {
-      if (declarationCount + scriptletCount + expressionCount 
-          + rtExpressionCount > 0) {
-	StringBuffer results = new StringBuffer("JSP page contains ");
-	boolean first = true;
-	if (declarationCount > 0) {
-	  results.append(Integer.toString(declarationCount));
-	  results.append(" declaration");
-	  if (declarationCount > 1) results.append('s');
-	  first = false;
-	}
-	if (scriptletCount > 0) {
-	  if (! first) results.append(", ");
-	  results.append(Integer.toString(scriptletCount));
-	  results.append(" scriptlet");
-	  if (scriptletCount > 1) results.append('s');
-	  first = false;
-	}
-	if (expressionCount > 0) {
-	  if (! first) results.append(", ");
-	  results.append(Integer.toString(expressionCount));
-	  results.append(" expression");
-	  if (expressionCount > 1) results.append('s');
-	  first = false;
-	}
-	if (rtExpressionCount > 0) {
-	  if (! first) results.append(", ");
-	  results.append(Integer.toString(rtExpressionCount));
-	  results.append(" request-time attribute value");
-	  if (rtExpressionCount > 1) results.append('s');
-	  first = false;
-	}
-	results.append(".");
-	return vmFromString(results.toString());
-      } else {
-	return null;
-      }
+    public ValidationMessage[] validate(String prefix, String uri, PageData page) {
+        InputStream in = null;
+        SAXParser parser;
+        MyContentHandler handler = new MyContentHandler();
+        try {
+            synchronized (factory) {
+                parser = factory.newSAXParser();
+            }
+            in = page.getInputStream();
+            parser.parse(in, handler);
+        } catch (ParserConfigurationException e) {
+            return vmFromString(e.toString());
+        } catch (SAXException e) {
+            return vmFromString(e.toString());
+        } catch (IOException e) {
+            return vmFromString(e.toString());
+        } finally {
+            if (in != null) {
+                try {
+                    in.close();
+                } catch (IOException e) {
+                }
+            }
+        }
+        return handler.reportResults();
     }
-  }
 
+    /**
+     * Handler for SAX events. Four counters are provided as instance variables, for counting occurrences of prohibited
+     * scripting elements.
+     */
+    private class MyContentHandler extends DefaultHandler {
+        private int declarationCount = 0;
+        private int scriptletCount = 0;
+        private int expressionCount = 0;
+        private int rtExpressionCount = 0;
 
-  // constructs a ValidationMessage[] from a single String and no ID
-  private static ValidationMessage[] vmFromString(String message) {
-    return new ValidationMessage[] {
-      new ValidationMessage(null, message)
-    };
-  }
+        /**
+         * This event is received whenever a new element is encountered. The qualified name of each such element is compared
+         * against the names of any prohibited scripting elements. When found, the corresponding counter is incremented. If
+         * expressions representing request-time attribute values are prohibited, it is also necessary to check the values of
+         * all attributes specified by the element. (Trying to figure out which attributes actually support request-time
+         * attribute values and checking only those is far more trouble than it's worth.)
+         */
+        public void startElement(String namespaceUri, String localName, String qualifiedName, Attributes atts) {
+            if (!allowDeclarations && qualifiedName.equals("jsp:declaration")) {
+                ++declarationCount;
+            } else if (!allowScriptlets && qualifiedName.equals("jsp:scriptlet")) {
+                ++scriptletCount;
+            } else if (!allowExpressions && qualifiedName.equals("jsp:expression")) {
+                ++expressionCount;
+            }
+            if (!allowRTExpressions) {
+                countRTExpressions(atts);
+            }
+        }
+
+        /**
+         * Auxiliary method for checking attribute values to see if are specified via request-time attribute values. Expressions
+         * representing request-time attribute values are recognized by their "%=" and "%" delimiters. When found, the
+         * corresponding counter is incremented.
+         */
+        private void countRTExpressions(Attributes atts) {
+            int stop = atts.getLength();
+            for (int i = 0; i < stop; ++i) {
+                String attval = atts.getValue(i);
+                if (attval.startsWith("%=") && attval.endsWith("%")) {
+                    ++rtExpressionCount;
+                }
+            }
+        }
+
+        /**
+         * Constructs a String reporting the number(s) of prohibited scripting elements that were detected, if any. Returns null
+         * if no violations were found, making the result of this method suitable for the return value of the
+         * TagLibraryValidator.validate() method.
+         * 
+         * TODO: The update from 7/13/2001 merely makes this validator compliant with the new TLV API, but does not fully take
+         * advantage of this API. In the future, we should do so... but because of the possibility that anti-script checking
+         * will be incorporated into the base TLV, I've held off for now and just changed this class to use the new API. -- SB.
+         */
+        public ValidationMessage[] reportResults() {
+            if (declarationCount + scriptletCount + expressionCount + rtExpressionCount > 0) {
+                StringBuffer results = new StringBuffer("JSP page contains ");
+                boolean first = true;
+                if (declarationCount > 0) {
+                    results.append(Integer.toString(declarationCount));
+                    results.append(" declaration");
+                    if (declarationCount > 1) {
+                        results.append('s');
+                    }
+                    first = false;
+                }
+                if (scriptletCount > 0) {
+                    if (!first) {
+                        results.append(", ");
+                    }
+                    results.append(Integer.toString(scriptletCount));
+                    results.append(" scriptlet");
+                    if (scriptletCount > 1) {
+                        results.append('s');
+                    }
+                    first = false;
+                }
+                if (expressionCount > 0) {
+                    if (!first) {
+                        results.append(", ");
+                    }
+                    results.append(Integer.toString(expressionCount));
+                    results.append(" expression");
+                    if (expressionCount > 1) {
+                        results.append('s');
+                    }
+                    first = false;
+                }
+                if (rtExpressionCount > 0) {
+                    if (!first) {
+                        results.append(", ");
+                    }
+                    results.append(Integer.toString(rtExpressionCount));
+                    results.append(" request-time attribute value");
+                    if (rtExpressionCount > 1) {
+                        results.append('s');
+                    }
+                    first = false;
+                }
+                results.append(".");
+                return vmFromString(results.toString());
+            } else {
+                return null;
+            }
+        }
+    }
+
+    // constructs a ValidationMessage[] from a single String and no ID
+    private static ValidationMessage[] vmFromString(String message) {
+        return new ValidationMessage[] { new ValidationMessage(null, message) };
+    }
 
 }


### PR DESCRIPTION
I noticed we never formatted the API code. This PR formats using the Jakarta EE/EE4J convention and applies some of the styles (like no `public` keyword needed for interface methods).

Signed-off-by: arjantijms <arjan.tijms@gmail.com>