### PR TITLE
Revert the license changes

### DIFF
--- a/api/src/main/javadoc/doc-files/EFSL.html
+++ b/api/src/main/javadoc/doc-files/EFSL.html
@@ -20,9 +20,8 @@
   <li>All existing copyright notices, or if one does not exist, a notice
       (hypertext is preferred, but a textual representation is permitted)
       of the form: &quot;Copyright &copy; [$date-of-document]
-      Eclipse Foundation, Inc. 
-	  <a href="https://www.eclipse.org/legal/efsl.php">
-	  https://www.eclipse.org/legal/efsl.php</a>&quot;
+      &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
+      &quot;
   </li>
 </ul>
 
@@ -43,11 +42,9 @@
 
 <p>The notice is:</p>
 
-<p>&quot;Copyright &copy; 2018, 2020 Eclipse Foundation. This software or
-  document includes material copied from or derived from Jakarta&reg; 
-  Standard Tag Library 
-  <a href="https://jakarta.ee/specifications/tags/2.0/">
-  https://jakarta.ee/specifications/tags/2.0/</a>.&quot;</p>
+<p><p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
+  document includes material copied from or derived from [title and URI
+  of the Eclipse Foundation specification document].&quot;</p>
 
 <h2>Disclaimers</h2>
 

--- a/spec/src/main/asciidoc/license-efsl.adoc
+++ b/spec/src/main/asciidoc/license-efsl.adoc
@@ -9,7 +9,7 @@ Status: {revremark}
 Release: {revdate}
 ....
 
-Copyright (c) 2018, 2020 Eclipse Foundation. https://www.eclipse.org/legal/efsl.php[]
+Copyright (c) 2018, 2020 Eclipse Foundation.
 
 === Eclipse Foundation Specification License
 
@@ -27,8 +27,8 @@ document, or portions thereof, that you use:
 * link or URL to the original Eclipse Foundation document.
 * All existing copyright notices, or if one does not exist, a notice
   (hypertext is preferred, but a textual representation is permitted)
-  of the form: "Copyright (C) [$date-of-document]
-  Eclipse Foundation, Inc. https://www.eclipse.org/legal/efsl.php[]"
+  of the form: "Copyright (c) [$date-of-document]
+  Eclipse Foundation, Inc. \<<url to this license>>"
 
 Inclusion of the full text of this NOTICE must be provided. We
 request that authorship attribution be provided in any software,
@@ -47,9 +47,9 @@ specification is expressly prohibited.
 
 The notice is:
 
-"Copyright (C) 2018, 2020 Eclipse Foundation. This software or
-document includes material copied from or derived from
-Jakarta(R) Standard Tag Library https://jakarta.ee/specifications/tags/2.0/[]"
+"Copyright (c) 2018 Eclipse Foundation. This software or
+document includes material copied from or derived from [title and URI
+of the Eclipse Foundation specification document]."
 
 ==== Disclaimers
 


### PR DESCRIPTION
Remove the changes that were made as part of https://github.com/eclipse-ee4j/jstl-api/issues/56

We are however keeping the updated `2018, 2020` copyright date in the `license.efsl.adoc` on line 12

For comparison when reviewing:

Javadoc changes originally made were: https://github.com/eclipse-ee4j/jstl-api/pull/82/files
Spec changes originally made were: https://github.com/eclipse-ee4j/jstl-api/pull/73/commits/19d01f311bbeefab04e3370faaca8ee7148a4a74