### PR TITLE
Main Branch: Remove PrintWriterWrapper from ImportSupport

### DIFF
--- a/impl/src/main/java/org/apache/taglibs/standard/tag/common/core/ImportSupport.java
+++ b/impl/src/main/java/org/apache/taglibs/standard/tag/common/core/ImportSupport.java
@@ -2,6 +2,7 @@
  * Copyright (c) 1997-2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  * Copyright (c) 2020 Payara Services Ltd.
+ * Copyright (c) 2021-2021 Contributors to the Eclipse Foundation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -463,7 +464,7 @@ public abstract class ImportSupport extends BodyTagSupport
 		throw new IllegalStateException(
 		    Resources.getMessage("IMPORT_ILLEGAL_STREAM"));
 	    isWriterUsed = true;
-	    return new PrintWriterWrapper(sw, pageContext.getOut());
+	    return new PrintWriter(sw);
 	}
 	
 	/** Returns a ServletOutputStream designed to buffer the output. */
@@ -512,27 +513,6 @@ public abstract class ImportSupport extends BodyTagSupport
 		return "";		// target didn't write anything
 	}
     }
-
-    private static class PrintWriterWrapper extends PrintWriter {
-
-        private StringWriter out;
-        private Writer parentWriter;
-
-        public PrintWriterWrapper(StringWriter out, Writer parentWriter) {
-            super(out);
-            this.out = out;
-            this.parentWriter = parentWriter;
-        }
-
-        public void flush() {
-            try {
-                parentWriter.write(out.toString());
-                StringBuffer sb = out.getBuffer();
-                sb.delete(0, sb.length());
-            } catch (IOException ex) {
-            }
-        }
-     }
 
     //*********************************************************************
     // Some private utility methods


### PR DESCRIPTION
Fixes #153 

Removing the `pageContext.getOut()` and the `PrintWriterWrapper` class , so any flushes within an imported page are _not_ outputted directly to the page. 

Data is stored in the StringWriter buffer until the variable it displayed on the page.  