### PR TITLE
Issue #115: Remove minor mistake in spec doc

### DIFF
--- a/spec/src/main/asciidoc/jakarta-stl.adoc
+++ b/spec/src/main/asciidoc/jakarta-stl.adoc
@@ -8208,4 +8208,3 @@ changes in the Jakarta Standard Tag Library specification. This appendix is non-
 <<< 
 
 '''''
-section of each action, as well as the syntax of EL expressions


### PR DESCRIPTION
fixes #115 during the changes made in #115 this error was made. This text was added to the end of the specification document on accident and needs to be removed.