### PR TITLE
Update TagLib URIs for EE10

### DIFF
--- a/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/package.html
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/package.html
@@ -42,7 +42,7 @@ Reusable Tag Library Validator (TLV) classes provided by the Jakarta Standard Ta
   &lt;display-name&gt;permittedTaglibs&lt;/display-name&gt;
   &lt;tlib-version&gt;1.1&lt;/tlib-version&gt;
   &lt;short-name&gt;permittedTaglibs&lt;/short-name&gt;
-  &lt;uri&gt;http://java.sun.com/jstl/permittedTaglibs&lt;/uri&gt;
+  &lt;uri&gt;http://jakarta.apache.org/taglibs/standard/permittedTaglibs&lt;/uri&gt;
 
   &lt;validator&gt;
     &lt;validator-class&gt;
@@ -54,10 +54,10 @@ Reusable Tag Library Validator (TLV) classes provided by the Jakarta Standard Ta
       &lt;/description&gt;
       &lt;param-name&gt;permittedTaglibs&lt;/param-name&gt;
       &lt;param-value&gt;
-        http://java.sun.com/jsp/jstl/core
-        http://java.sun.com/jsp/jstl/fmt
-        http://java.sun.com/jsp/jstl/sql
-        http://java.sun.com/jsp/jstl/xml
+          jakarta.tags.core
+          jakarta.tags.fmt
+          jakarta.tags.sql
+          jakarta.tags.xml
       &lt;/param-value&gt;
     &lt;/init-param&gt;
   &lt;/validator&gt;

--- a/impl/src/main/resources/META-INF/c.tld
+++ b/impl/src/main/resources/META-INF/c.tld
@@ -26,7 +26,7 @@
   <display-name>JSTL core</display-name>
   <tlib-version>1.2</tlib-version>
   <short-name>c</short-name>
-  <uri>http://java.sun.com/jsp/jstl/core</uri>
+  <uri>jakarta.tags.core</uri>
 
   <validator>
     <description>

--- a/impl/src/main/resources/META-INF/fmt.tld
+++ b/impl/src/main/resources/META-INF/fmt.tld
@@ -26,7 +26,7 @@
   <display-name>JSTL fmt</display-name>
   <tlib-version>1.1</tlib-version>
   <short-name>fmt</short-name>
-  <uri>http://java.sun.com/jsp/jstl/fmt</uri>
+  <uri>jakarta.tags.fmt</uri>
 
   <validator>
     <description>

--- a/impl/src/main/resources/META-INF/fn.tld
+++ b/impl/src/main/resources/META-INF/fn.tld
@@ -26,7 +26,7 @@
   <display-name>JSTL functions</display-name>
   <tlib-version>1.1</tlib-version>
   <short-name>fn</short-name>
-  <uri>http://java.sun.com/jsp/jstl/functions</uri>
+  <uri>jakarta.tags.functions</uri>
 
   <function>
     <description>

--- a/impl/src/main/resources/META-INF/permittedTaglibs.tld
+++ b/impl/src/main/resources/META-INF/permittedTaglibs.tld
@@ -41,10 +41,10 @@
       </description>        
       <param-name>permittedTaglibs</param-name>
       <param-value>
-	http://java.sun.com/jsp/jstl/core
-	http://java.sun.com/jsp/jstl/fmt
-	http://java.sun.com/jsp/jstl/sql
-	http://java.sun.com/jsp/jstl/xml
+	jakarta.tags.core
+	jakarta.tags.fmt
+	jakarta.tags.sql
+	jakarta.tags.xml
       </param-value>
     </init-param>
   </validator>

--- a/impl/src/main/resources/META-INF/sql.tld
+++ b/impl/src/main/resources/META-INF/sql.tld
@@ -26,7 +26,7 @@
   <display-name>JSTL sql</display-name>
   <tlib-version>1.1</tlib-version>
   <short-name>sql</short-name>
-  <uri>http://java.sun.com/jsp/jstl/sql</uri>
+  <uri>jakarta.tags.sql</uri>
 
   <validator>
     <description>

--- a/impl/src/main/resources/META-INF/x.tld
+++ b/impl/src/main/resources/META-INF/x.tld
@@ -26,7 +26,7 @@
   <display-name>JSTL XML</display-name>
   <tlib-version>1.1</tlib-version>
   <short-name>x</short-name>
-  <uri>http://java.sun.com/jsp/jstl/xml</uri>
+  <uri>jakarta.tags.xml</uri>
 
   <validator>
     <description>

--- a/spec/src/main/asciidoc/jakarta-stl.adoc
+++ b/spec/src/main/asciidoc/jakarta-stl.adoc
@@ -221,21 +221,21 @@ Jakarta Standard Tag Library Tag Libraries
 |Functional Area
 |URI |Prefix
 |core |
-_http://java.sun.com/jsp/jstl/core_ | _c_
+_jakarta.tags.core_ | _c_
 
 |XML processing |
-_http://java.sun.com/jsp/jstl/xml_ | _x_
+_jakarta.tags.xml_ | _x_
 
 |I18N capable formatting
-| _http://java.sun.com/jsp/jstl/fmt_
+| _jakarta.tags.fmt_
 | _fmt_
 
 |relational db access (SQL)
-| _http://java.sun.com/jsp/jstl/sql_
+| _jakarta.tags.sql_
 | _sql_
 
 |Functions |
-_http://java.sun.com/jsp/jstl/functions_ |fn
+_jakarta.tags.functions_ |fn
 |===
 
 === Container Requirement
@@ -7226,8 +7226,7 @@ libraries), a developer could create the following TLD:
 ....
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<taglib
-    xmlns="http://java.sun.com/xml/ns/j2ee"
+<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation=
         "http://java.sun.com/xml/ns/j2ee web jsptaglibrary_2_0.xsd"
@@ -7247,10 +7246,10 @@ libraries), a developer could create the following TLD:
         <init-param>
             <param-name>permittedTaglibs</param-name>
             <param-value>
-                http://java.sun.com/jstl/core
-                http://java.sun.com/jstl/xml
-                http://java.sun.com/jstl/fmt
-                http://java.sun.com/jstl/sql
+                jakarta.tags.core
+                jakarta.tags.xml
+                jakarta.tags.fmt
+                jakarta.tags.sql
             </param-value>
         </init-param>
     </validator>
@@ -8205,6 +8204,8 @@ changes in the Jakarta Standard Tag Library specification. This appendix is non-
 ** https://github.com/eclipse-ee4j/jstl-api/issues/156 : Update Jakarta Tags to Java 11
 
 ** https://github.com/eclipse-ee4j/jstl-api/issues/157 : Add JPMS Module Info Class
+
+** https://github.com/eclipse-ee4j/jstl-api/issues/144 : Rename Tag URIs to 'jakarta.tags.*'
 
 === Changed between Jakarta Standard Tag Library 2.0 and JSR-52
 


### PR DESCRIPTION
for issue #144 

- I only changed the TLD URIs in some files (those listed under permittedTaglibs.tld which are limited to JSP pages). Once these TLDs are updated, the server container & JSP engine handles the rest based on my understanding & testing. 
- Updated the spec document

TLD docs list the new URIs as so: `<%@ taglib prefix="c" uri="jakarta.tags.core" %>` 

I tested the new implementation on Tomcat 10.0.12, and  the new URIs work well. If the old ones were used, then the server encountered the following error: 
```
org.apache.jasper.JasperException: The absolute uri: [http://java.sun.com/jsp/jstl/core] cannot be resolved in either web.xml or the jar files deployed with this application
	org.apache.jasper.compiler.DefaultErrorHandler.jspError(DefaultErrorHandler.java:54)
	org.apache.jasper.compiler.ErrorDispatcher.dispatch(ErrorDispatcher.java:294)
	org.apache.jasper.compiler.ErrorDispatcher.jspError(ErrorDispatcher.java:81)
	org.apache.jasper.compiler.TagLibraryInfoImpl.generateTldResourcePath(TagLibraryInfoImpl.java:251)
	org.apache.jasper.compiler.TagLibraryInfoImpl.<init>(TagLibraryInfoImpl.java:122)
	org.apache.jasper.compiler.Parser.parseTaglibDirective(Parser.java:429
```


Questions:

Should there be backwards compatibility with the new and old URIs? 

**JSP Root URI**
Should this change? Do we need to wait for the Pages-Api project? 
https://github.com/eclipse-ee4j/jstl-api/blob/2a60c5505d3466c49e8f4ab1e49ef42ec0e5e7a3/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/PermittedTaglibsTLV.java#L63

**Other TLDs**
What should we do with the older TLDs? They use "http://java.sun.com/jstl/" instead of "http://java.sun.com/jsp/jstl/" 
https://github.com/eclipse-ee4j/jstl-api/blob/2a60c5505d3466c49e8f4ab1e49ef42ec0e5e7a3/impl/src/main/resources/META-INF/sql-1_0.tld#L27 

XPath
Not sure what this is about. Seems safe to change?
https://github.com/eclipse-ee4j/jstl-api/blob/2a60c5505d3466c49e8f4ab1e49ef42ec0e5e7a3/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/JSTLXPathImpl.java#L188

XPath
Not sure where the `http://java.sun.com/jstl/xpath` namespace is used or how? Could just be local in this impl?  
https://github.com/eclipse-ee4j/jstl-api/blob/2a60c5505d3466c49e8f4ab1e49ef42ec0e5e7a3/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/JSTLXPathVariableResolver.java#L40-L43

Schema Namespaces for TLDs
Still waiting for new EE 10 schemas: https://jakarta.ee/xml/ns/jakartaee/#10  Only a few are out and they are still drafts. 
https://github.com/eclipse-ee4j/jstl-api/blob/2a60c5505d3466c49e8f4ab1e49ef42ec0e5e7a3/impl/src/main/resources/META-INF/c.tld#L20-L23
Using EE9 schemas give me the following error: 
```
[INFO] --- exec-maven-plugin:3.0.0:java (generateTldDoc) @ jakarta.servlet.jsp.jstl ---
Loading and translating 5 Tag Libraries...
com.sun.tlddoc.GeneratorException: Error: /Users/siedlecki/open-source/jstl-api/impl/src/main/resources/META-INF/x.tld does not have xmlns="http://java.sun.com/xml/ns/javaee"
        at com.sun.tlddoc.TLDDocGenerator.createTLDSummaryDoc(TLDDocGenerator.java:555)
        at com.sun.tlddoc.TLDDocGenerator.generate(TLDDocGenerator.java:440)
        at com.sun.tlddoc.TLDDoc.main(TLDDoc.java:217)
        at org.codehaus.mojo.exec.ExecJavaMojo$1.run(ExecJavaMojo.java:254)
        at java.base/java.lang.Thread.run(Thread.java:834)
```

Should we update the example? 
https://github.com/eclipse-ee4j/jstl-api/blame/2a60c5505d3466c49e8f4ab1e49ef42ec0e5e7a3/spec/src/main/asciidoc/jakarta-stl.adoc#L7225-L7255

This should also be updated?
https://github.com/eclipse-ee4j/jstl-api/blob/master/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/package.html

Other URIs that need to be updated? Such as
https://github.com/eclipse-ee4j/jstl-api/blob/2a60c5505d3466c49e8f4ab1e49ef42ec0e5e7a3/impl/src/main/resources/META-INF/permittedTaglibs.tld#L30 