### PR TITLE
Add module info

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -197,7 +197,6 @@
                         <supportedProjectType>jar</supportedProjectType>
                     </supportedProjectTypes>
                     <instructions>
-                        <Automatic-Module-Name>jakarta.servlet.jsp.jstl</Automatic-Module-Name>
                         <Bundle-Version>${spec.bundle.version}</Bundle-Version>
                         <Bundle-SymbolicName>${spec.bundle.symbolic-name}</Bundle-SymbolicName>
                         <Extension-Name>${spec.extension.name}</Extension-Name>

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+module jakarta.servlet.jsp.jstl {
+    exports jakarta.servlet.jsp.jstl.core;
+    exports jakarta.servlet.jsp.jstl.fmt;
+    exports jakarta.servlet.jsp.jstl.sql;
+    exports jakarta.servlet.jsp.jstl.tlv;
+
+    requires transitive jakarta.el;
+    requires transitive jakarta.servlet;
+    requires transitive jakarta.servlet.jsp;
+    requires transitive java.sql;
+    requires transitive java.desktop;
+}

--- a/api/src/main/java/module-info.java
+++ b/api/src/main/java/module-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2021-2021 Contributors to the Eclipse Foundation
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/spec/src/main/asciidoc/jakarta-stl.adoc
+++ b/spec/src/main/asciidoc/jakarta-stl.adoc
@@ -8200,6 +8200,8 @@ changes in the Jakarta Standard Tag Library specification. This appendix is non-
 
 ** https://github.com/eclipse-ee4j/jstl-api/issues/156 : Update Jakarta Tags to Java 11
 
+** https://github.com/eclipse-ee4j/jstl-api/issues/157 : Add JPMS Module Info Class
+
 === Changed between Jakarta Standard Tag Library 2.0 and JSR-52
 
 ** The API has moved from the `javax.servlet.jsp.jstl` package to the `jakarta.servlet.jsp.jstl` package.


### PR DESCRIPTION
fixes #157

Module name is jakarta.servlet.jsp.jstl (Per the naming [conventions](https://github.com/jakartaee/specification-committee/blob/master/names.adoc))
Exports the 4 API packages

I listed it to require 5 modules (otherwise, you'll encounter build errors).  I believe marking them transitive is correct. Other projects that pull in JSTL will **not** need to explicitly list those modules.  I referred to the links below and used the jsp-api module-info.java as a guide.

Please let me know if you see any errors. Thanks!

References: 
https://github.com/eclipse-ee4j/jsp-api/blob/master/api/src/main/java/module-info.java

Sources: 
https://www.oracle.com/corporate/features/understanding-java-9-modules.html 
https://stackoverflow.com/questions/46502453/whats-the-difference-between-requires-and-requires-transitive-statements-in-jav