### PR TITLE
Only keep important changes.

### DIFF
--- a/spec/src/main/asciidoc/jakarta-stl.adoc
+++ b/spec/src/main/asciidoc/jakarta-stl.adoc
@@ -8197,8 +8197,6 @@ changes in the Jakarta Standard Tag Library specification. This appendix is non-
 
 === Changed between Jakarta Standard Tag Library 2.0 and Jakarta Standard Tag Library 3.0
 
-** https://github.com/eclipse-ee4j/jstl-api/issues/115 : Update Expression Language links in the specification document
-
 ** https://github.com/eclipse-ee4j/jstl-api/issues/149 : Remove dependency on XML Binding from the API pom
 
 ** https://github.com/eclipse-ee4j/jstl-api/issues/156 : Update Jakarta Tags to Java 11


### PR DESCRIPTION
fixes #168

We don't need to add every minor spec document change to the change history. Just having the important spec/api changes is enough to avoid being too verbose.