### PR TITLE
Re-fix  javax references to jakarta via tlddoc source

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -469,30 +469,6 @@ Copyright &#169; 2019, ${current.year} Eclipse Foundation. All rights reserved.
 							</dependency>
 						</dependencies>
 					</plugin>
-					
-					<!-- Update incorrect javax.el.ValueExpression references to jakarta.el.ValueExpression. -->
-		            <plugin>
-		                <groupId>org.apache.maven.plugins</groupId>
-		                <artifactId>maven-antrun-plugin</artifactId>
-		                <version>3.0.0</version>
-		                <executions>
-		                    <execution>
-		                        <id>generate-tlddoc-post-process</id>
-		                        <phase>package</phase>
-		                        <goals>
-		                            <goal>run</goal>
-		                        </goals>
-		                        <configuration>
-		                            <target>
-		                                <echo level="info">Replacing in ${project.build.directory}/tlddoc</echo>
-		                                <replace token="javax.el.ValueExpression" value="jakarta.el.ValueExpression" dir="${project.build.directory}/tlddoc" summary="yes">
-		                                    <include name="**/*.html"/>
-		                                </replace>
-		                            </target>
-		                        </configuration>
-		                    </execution>
-		                </executions>
-		            </plugin>
 				</plugins>
 			</build>
 		</profile>

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tag.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tag.html.xsl
@@ -3,6 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
+  - Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 
@@ -361,12 +362,12 @@
             <xsl:when test="javaee:deferred-value">
                 <xsl:choose>
                     <xsl:when test="javaee:deferred-value/javaee:type">
-                        <code>javax.el.ValueExpression</code>
+                        <code>jakarta.el.ValueExpression</code>
                         <br/>(<i>must evaluate to </i><code><xsl:value-of
                                 select="javaee:deferred-value/javaee:type"/></code>)
                     </xsl:when>
                     <xsl:otherwise>
-                        <code>javax.el.ValueExpression</code>
+                        <code>jakarta.el.ValueExpression</code>
                         <br/>(<i>must evaluate to </i><code>java.lang.Object</code>)
                     </xsl:otherwise>
                 </xsl:choose>                                
@@ -374,12 +375,12 @@
             <xsl:when test="javaee:deferred-method">
                 <xsl:choose>
                     <xsl:when test="javaee:deferred-method/javaee:method-signature">
-                        <code>javax.el.MethodExpression</code>
+                        <code>jakarta.el.MethodExpression</code>
                         <br/>(<i>signature must match </i><code><xsl:value-of
                                 select="javaee:deferred-method/javaee:method-signature"/></code>)
                     </xsl:when>
                     <xsl:otherwise>
-                        <code>javax.el.MethodExpression</code>
+                        <code>jakarta.el.MethodExpression</code>
                         <br/>(<i>signature must match </i><code>void methodname()</code>)
                     </xsl:otherwise>
                 </xsl:choose>


### PR DESCRIPTION
Redo fix for #131 now that we have the TLDDoc source.