### PR TITLE
Update TLDS to the Jakarta EE10 namespace (with TLDDoc Updates)

### DIFF
--- a/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/package.html
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/package.html
@@ -32,17 +32,17 @@ Reusable Tag Library Validator (TLV) classes provided by the Jakarta Standard Ta
 <pre>
 &lt;?xml version="1.0" encoding="UTF-8" ?&gt;
 
-&lt;taglib xmlns="http://java.sun.com/xml/ns/javaee"
+&lt;taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
-    version="2.1"&gt;
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd"
+    version="3.0"&gt;
   &lt;description&gt;
     Restricts JSP pages to the JSTL tag libraries
   &lt;/description&gt;
   &lt;display-name&gt;permittedTaglibs&lt;/display-name&gt;
-  &lt;tlib-version&gt;1.1&lt;/tlib-version&gt;
+  &lt;tlib-version&gt;3.0&lt;/tlib-version&gt;
   &lt;short-name&gt;permittedTaglibs&lt;/short-name&gt;
-  &lt;uri&gt;http://jakarta.apache.org/taglibs/standard/permittedTaglibs&lt;/uri&gt;
+  &lt;uri&gt;jakarta.tags.permittedTaglibs&lt;/uri&gt;
 
   &lt;validator&gt;
     &lt;validator-class&gt;

--- a/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/package.html
+++ b/api/src/main/java/jakarta/servlet/jsp/jstl/tlv/package.html
@@ -2,7 +2,8 @@
 
     Copyright (c) 1997-2020 Oracle and/or its affiliates. All rights reserved.
     Copyright 2004 The Apache Software Foundation
-
+    Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
+    
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/impl/src/main/resources/META-INF/c.tld
+++ b/impl/src/main/resources/META-INF/c.tld
@@ -18,9 +18,10 @@
 
 -->
 
- <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd" version="3.0">
-
-
+<taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd"
+    version="3.0">
     
   <description>Tags 3.0 core library</description>
   <display-name>Tags core</display-name>

--- a/impl/src/main/resources/META-INF/c.tld
+++ b/impl/src/main/resources/META-INF/c.tld
@@ -18,10 +18,9 @@
 
 -->
 
-<taglib xmlns="http://java.sun.com/xml/ns/javaee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd"
-    version="2.1">
+ <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd" version="3.0">
+
+
     
   <description>Tags 3.0 core library</description>
   <display-name>Tags core</display-name>

--- a/impl/src/main/resources/META-INF/fmt.tld
+++ b/impl/src/main/resources/META-INF/fmt.tld
@@ -18,9 +18,10 @@
 
 -->
 
- <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd" version="3.0">
-
-
+<taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd"
+    version="3.0">
     
   <description>Tags 3.0 i18n-capable formatting library</description>
   <display-name>Tags fmt</display-name>

--- a/impl/src/main/resources/META-INF/fmt.tld
+++ b/impl/src/main/resources/META-INF/fmt.tld
@@ -18,10 +18,9 @@
 
 -->
 
-<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
-    version="2.0">
+ <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd" version="3.0">
+
+
     
   <description>Tags 3.0 i18n-capable formatting library</description>
   <display-name>Tags fmt</display-name>

--- a/impl/src/main/resources/META-INF/fn.tld
+++ b/impl/src/main/resources/META-INF/fn.tld
@@ -18,9 +18,10 @@
 
 -->
 
- <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd" version="3.0">
-
-
+<taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd"
+    version="3.0">
     
   <description>Tags 3.0 functions library</description>
   <display-name>Tags functions</display-name>

--- a/impl/src/main/resources/META-INF/fn.tld
+++ b/impl/src/main/resources/META-INF/fn.tld
@@ -18,10 +18,9 @@
 
 -->
 
-<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
-  version="2.0">
+ <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd" version="3.0">
+
+
     
   <description>Tags 3.0 functions library</description>
   <display-name>Tags functions</display-name>

--- a/impl/src/main/resources/META-INF/sql.tld
+++ b/impl/src/main/resources/META-INF/sql.tld
@@ -18,9 +18,10 @@
 
 -->
 
- <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd" version="3.0">
-
-
+<taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd"
+    version="3.0">
     
   <description>Tags 3.0 sql library</description>
   <display-name>Tags sql</display-name>

--- a/impl/src/main/resources/META-INF/sql.tld
+++ b/impl/src/main/resources/META-INF/sql.tld
@@ -18,10 +18,9 @@
 
 -->
 
-<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
-    version="2.0">
+ <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd" version="3.0">
+
+
     
   <description>Tags 3.0 sql library</description>
   <display-name>Tags sql</display-name>

--- a/impl/src/main/resources/META-INF/x.tld
+++ b/impl/src/main/resources/META-INF/x.tld
@@ -18,9 +18,10 @@
 
 -->
 
- <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd" version="3.0">
-
-
+<taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd"
+    version="3.0">
     
   <description>Tags 3.0 XML library</description>
   <display-name>Tags XML</display-name>

--- a/impl/src/main/resources/META-INF/x.tld
+++ b/impl/src/main/resources/META-INF/x.tld
@@ -18,10 +18,9 @@
 
 -->
 
-<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://java.sun.com/xml/ns/j2ee http://java.sun.com/xml/ns/j2ee/web-jsptaglibrary_2_0.xsd"
-    version="2.0">
+ <taglib xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd" version="3.0">
+
+
     
   <description>Tags 3.0 XML library</description>
   <display-name>Tags XML</display-name>

--- a/spec/src/main/asciidoc/jakarta-stl.adoc
+++ b/spec/src/main/asciidoc/jakarta-stl.adoc
@@ -7178,11 +7178,10 @@ developer could create the following TLD:
 ....
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation=
-        "http://java.sun.com/xml/ns/j2ee web jsptaglibrary_2_0.xsd"
-    version="2.0">
+<taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd"
+    version="3.0">
     <description>
         Validates Jakarta Server Pages to prohibit use of scripting elements.
     </description>
@@ -7226,11 +7225,10 @@ libraries), a developer could create the following TLD:
 ....
 <?xml version="1.0" encoding="UTF-8" ?>
 
-<taglib xmlns="http://java.sun.com/xml/ns/j2ee"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation=
-        "http://java.sun.com/xml/ns/j2ee web jsptaglibrary_2_0.xsd"
-    version="2.0">
+<taglib xmlns="https://jakarta.ee/xml/ns/jakartaee"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-jsptaglibrary_3_0.xsd"
+    version="3.0">
     <description>
         Restricts Jakarta Server Pages to the Jakarta Standard Tag Library tag libraries
     </description>

--- a/tagsdoc/src/main/java/com/sun/tlddoc/Constants.java
+++ b/tagsdoc/src/main/java/com/sun/tlddoc/Constants.java
@@ -1,6 +1,7 @@
 /*
  * <license>
  * Copyright (c) 2003-2004, Sun Microsystems, Inc.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without 
@@ -50,11 +51,8 @@ public final class Constants {
     public static final String DEFAULT_DOC_TITLE =
         "Tag Library Documentation Generator - Generated Documentation";
     
-    /** Namespace for Java EE */
-    public static final String NS_JAVAEE = "http://java.sun.com/xml/ns/javaee";
-    
-    /** Namespace for J2EE */
-    public static final String NS_J2EE = "http://java.sun.com/xml/ns/j2ee";
+    /** Namespace for Jakarta EE */
+    public static final String NS_JAKARTAEE = "https://jakarta.ee/xml/ns/jakartaee";
     
     /** If true, outputs the input to the transform before generation */
     public static final boolean DEBUG_INPUT_DOCUMENT = false;

--- a/tagsdoc/src/main/java/com/sun/tlddoc/Constants.java
+++ b/tagsdoc/src/main/java/com/sun/tlddoc/Constants.java
@@ -1,7 +1,7 @@
 /*
  * <license>
  * Copyright (c) 2003-2004, Sun Microsystems, Inc.
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without 

--- a/tagsdoc/src/main/java/com/sun/tlddoc/TLDDocGenerator.java
+++ b/tagsdoc/src/main/java/com/sun/tlddoc/TLDDocGenerator.java
@@ -499,24 +499,24 @@ public class TLDDocGenerator {
         summaryTLD = documentBuilder.newDocument();
         
         // Create root <tlds> element:
-        Element rootElement = summaryTLD.createElementNS( Constants.NS_JAVAEE, 
+        Element rootElement = summaryTLD.createElementNS( Constants.NS_JAKARTAEE, 
             "tlds" );
         summaryTLD.appendChild( rootElement );
         // JDK 1.4 does not add xmlns for some reason - add it manually:
         rootElement.setAttributeNS( "http://www.w3.org/2000/xmlns/", 
-            "xmlns", Constants.NS_JAVAEE );
+            "xmlns", Constants.NS_JAKARTAEE );
         
         // Create configuration element:
-        Element configElement = summaryTLD.createElementNS( Constants.NS_JAVAEE, 
+        Element configElement = summaryTLD.createElementNS( Constants.NS_JAKARTAEE, 
             "config" );
         rootElement.appendChild( configElement );
         
-        Element windowTitle = summaryTLD.createElementNS( Constants.NS_JAVAEE, 
+        Element windowTitle = summaryTLD.createElementNS( Constants.NS_JAKARTAEE, 
             "window-title" );
         windowTitle.appendChild( summaryTLD.createTextNode( this.windowTitle));
         configElement.appendChild( windowTitle );
         
-        Element docTitle = summaryTLD.createElementNS( Constants.NS_JAVAEE, 
+        Element docTitle = summaryTLD.createElementNS( Constants.NS_JAKARTAEE, 
             "doc-title" );
         docTitle.appendChild( summaryTLD.createTextNode( this.docTitle));
         configElement.appendChild( docTitle );
@@ -551,11 +551,10 @@ public class TLDDocGenerator {
 
                 Element taglibNode = (Element)summaryTLD.importNode( 
                     doc.getDocumentElement(), true );
-                if( !taglibNode.getNamespaceURI().equals( Constants.NS_JAVAEE )
-                    && !taglibNode.getNamespaceURI().equals( Constants.NS_J2EE )) {
+                if( !taglibNode.getNamespaceURI().equals( Constants.NS_JAKARTAEE ) ) {
                     throw new GeneratorException( "Error: " + 
                         tagLibrary.getPathDescription() + 
-                        " does not have xmlns=\"" + Constants.NS_JAVAEE + "\"" );
+                        " does not have xmlns=\"" + Constants.NS_JAKARTAEE + "\"" );
                 }
                 if( !taglibNode.getLocalName().equals( "taglib" ) ) {
                     throw new GeneratorException( "Error: " + 
@@ -749,7 +748,7 @@ public class TLDDocGenerator {
                 name.equals( "description" ) ||
                 name.equals( "example" ) )
             {
-                element = doc.createElementNS( Constants.NS_JAVAEE, name );
+                element = doc.createElementNS( Constants.NS_JAKARTAEE, name );
                 element.appendChild( doc.createTextNode( value ) );
                 tagFileNode.appendChild( element );
             }
@@ -759,13 +758,13 @@ public class TLDDocGenerator {
                 NodeList icons = tagFileNode.getElementsByTagNameNS( "*", "icon" );
                 Element icon;
                 if( icons.getLength() == 0 ) {
-                    icon = doc.createElementNS( Constants.NS_JAVAEE, "icon" );
+                    icon = doc.createElementNS( Constants.NS_JAKARTAEE, "icon" );
                     tagFileNode.appendChild( icon );
                 }
                 else {
                     icon = (Element)icons.item( 0 );
                 }
-                element = doc.createElementNS( Constants.NS_JAVAEE, name );
+                element = doc.createElementNS( Constants.NS_JAKARTAEE, name );
                 element.appendChild( doc.createTextNode( value ) );
                 icon.appendChild( element );
             }
@@ -805,7 +804,7 @@ public class TLDDocGenerator {
         String defaultValue ) 
     {
         if( findElementValue( parent, tagName ) == null ) {
-            Element element = doc.createElementNS( Constants.NS_JAVAEE, tagName );
+            Element element = doc.createElementNS( Constants.NS_JAKARTAEE, tagName );
             element.appendChild( doc.createTextNode( defaultValue ) );
             parent.appendChild( element );
         }
@@ -824,7 +823,7 @@ public class TLDDocGenerator {
         Element tagFileNode, Document doc, Directive directive )
     {
         Iterator attributes = directive.getAttributes();
-        Element attributeNode = doc.createElementNS( Constants.NS_JAVAEE, 
+        Element attributeNode = doc.createElementNS( Constants.NS_JAKARTAEE, 
             "attribute" );
         tagFileNode.appendChild( attributeNode );
         String deferredValueType = null;
@@ -841,7 +840,7 @@ public class TLDDocGenerator {
                 name.equals( "type" ) ||
                 name.equals( "description" ) )
             {
-                element = doc.createElementNS( Constants.NS_JAVAEE, name );
+                element = doc.createElementNS( Constants.NS_JAKARTAEE, name );
                 element.appendChild( doc.createTextNode( value ) );
                 attributeNode.appendChild( element );
             }
@@ -864,19 +863,19 @@ public class TLDDocGenerator {
         }
         if(deferredValueType != null) {
             Element deferredValueElement =
-                doc.createElementNS(Constants.NS_JAVAEE, "deferred-value");
+                doc.createElementNS(Constants.NS_JAKARTAEE, "deferred-value");
             attributeNode.appendChild(deferredValueElement);
             Element typeElement =
-                doc.createElementNS(Constants.NS_JAVAEE, "type");
+                doc.createElementNS(Constants.NS_JAKARTAEE, "type");
             typeElement.appendChild(doc.createTextNode(deferredValueType));
             deferredValueElement.appendChild(typeElement);
         }
         if(deferredMethodSignature != null) {
             Element deferredMethodElement =
-                doc.createElementNS(Constants.NS_JAVAEE, "deferred-method");
+                doc.createElementNS(Constants.NS_JAKARTAEE, "deferred-method");
             attributeNode.appendChild(deferredMethodElement);
             Element methodSignatureElement =
-                doc.createElementNS(Constants.NS_JAVAEE, "method-signature");
+                doc.createElementNS(Constants.NS_JAKARTAEE, "method-signature");
             methodSignatureElement.appendChild(
                 doc.createTextNode(deferredMethodSignature));
             deferredMethodElement.appendChild(methodSignatureElement);
@@ -908,7 +907,7 @@ public class TLDDocGenerator {
         Element tagFileNode, Document doc, Directive directive )
     {
         Iterator attributes = directive.getAttributes();
-        Element variableNode = doc.createElementNS( Constants.NS_JAVAEE, 
+        Element variableNode = doc.createElementNS( Constants.NS_JAKARTAEE, 
             "variable" );
         tagFileNode.appendChild( variableNode );
         while( attributes.hasNext() ) {
@@ -923,7 +922,7 @@ public class TLDDocGenerator {
                 name.equals( "scope" ) ||
                 name.equals( "description" ) )
             {
-                element = doc.createElementNS( Constants.NS_JAVAEE, name );
+                element = doc.createElementNS( Constants.NS_JAKARTAEE, name );
                 element.appendChild( doc.createTextNode( value ) );
                 variableNode.appendChild( element );
             }
@@ -950,7 +949,7 @@ public class TLDDocGenerator {
         {
             String prefix = "prefix" + substitutePrefix;
             substitutePrefix++;
-            Element shortName = doc.createElementNS( Constants.NS_JAVAEE, 
+            Element shortName = doc.createElementNS( Constants.NS_JAKARTAEE, 
                 "short-name" );
             shortName.appendChild( doc.createTextNode( prefix ) );
             root.appendChild( shortName );
@@ -999,7 +998,7 @@ public class TLDDocGenerator {
                     
                     // Create <type> element and append to attribute
                     Element typeElement = doc.createElementNS( 
-                        Constants.NS_JAVAEE, "type" );
+                        Constants.NS_JAKARTAEE, "type" );
                     typeElement.appendChild( 
                         doc.createTextNode( defaultType ) );
                     attributeElement.appendChild( typeElement );

--- a/tagsdoc/src/main/java/com/sun/tlddoc/TagDirImplicitTagLibrary.java
+++ b/tagsdoc/src/main/java/com/sun/tlddoc/TagDirImplicitTagLibrary.java
@@ -1,6 +1,7 @@
 /*
  * <license>
  * Copyright (c) 2003-2004, Sun Microsystems, Inc.
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without 
@@ -183,16 +184,16 @@ public class TagDirImplicitTagLibrary
         String path ) 
     {
         Element taglibElement = result.createElementNS(
-            Constants.NS_JAVAEE, "taglib" );
+            Constants.NS_JAKARTAEE, "taglib" );
         // JDK 1.4 does not add xmlns for some reason - add it manually:
         taglibElement.setAttributeNS( "http://www.w3.org/2000/xmlns/", 
-            "xmlns", Constants.NS_JAVAEE );
+            "xmlns", Constants.NS_JAKARTAEE );
         taglibElement.setAttributeNS( "http://www.w3.org/2000/xmlns/", 
             "xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance" );
         taglibElement.setAttributeNS( 
             "http://www.w3.org/2001/XMLSchema-instance",
             "xsi:schemaLocation", 
-            Constants.NS_JAVAEE + 
+            Constants.NS_JAKARTAEE + 
             " http://java.sun.com/xml/ns/javaee/web-jsptaglibrary_2_1.xsd" );
         taglibElement.setAttribute( "version", "2.1" );
         result.appendChild( taglibElement );

--- a/tagsdoc/src/main/java/com/sun/tlddoc/TagDirImplicitTagLibrary.java
+++ b/tagsdoc/src/main/java/com/sun/tlddoc/TagDirImplicitTagLibrary.java
@@ -1,7 +1,7 @@
 /*
  * <license>
  * Copyright (c) 2003-2004, Sun Microsystems, Inc.
- * Copyright (c) 2022 Contributors to the Eclipse Foundation
+ * Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without 

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/alltags-frame.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/alltags-frame.html.xsl
@@ -3,7 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
-  - Copyright (c) 2022 Contributors to the Eclipse Foundation
+  - Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/alltags-frame.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/alltags-frame.html.xsl
@@ -3,6 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
+  - Copyright (c) 2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 
@@ -41,7 +42,7 @@
 -->
 
 <xsl:stylesheet version="1.0"
-    xmlns:javaee="http://java.sun.com/xml/ns/javaee" 
+    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee" 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format">
     
@@ -68,9 +69,9 @@
             <tr>
               <td nowrap="true"><font class="FrameItemFont">
                 <xsl:apply-templates 
-                    select="javaee:tlds/javaee:taglib/javaee:tag|javaee:tlds/javaee:taglib/javaee:tag-file|javaee:tlds/javaee:taglib/javaee:function">
-                  <xsl:sort select="../javaee:short-name"/>
-                  <xsl:sort select="javaee:name"/>
+                    select="jakartaee:tlds/jakartaee:taglib/jakartaee:tag|jakartaee:tlds/jakartaee:taglib/jakartaee:tag-file|jakartaee:tlds/jakartaee:taglib/jakartaee:function">
+                  <xsl:sort select="../jakartaee:short-name"/>
+                  <xsl:sort select="jakartaee:name"/>
                 </xsl:apply-templates>
               </font></td>
             </tr>
@@ -79,11 +80,11 @@
       </html>    
     </xsl:template>
     
-    <xsl:template match="javaee:tag|javaee:tag-file">
+    <xsl:template match="jakartaee:tag|jakartaee:tag-file">
       <xsl:element name="a">
-        <xsl:attribute name="href"><xsl:value-of select="../javaee:short-name"/>/<xsl:value-of select="javaee:name"/>.html</xsl:attribute>
+        <xsl:attribute name="href"><xsl:value-of select="../jakartaee:short-name"/>/<xsl:value-of select="jakartaee:name"/>.html</xsl:attribute>
         <xsl:attribute name="target">tagFrame</xsl:attribute>
-        <xsl:value-of select="../javaee:short-name"/>:<xsl:value-of select="javaee:name"/>
+        <xsl:value-of select="../jakartaee:short-name"/>:<xsl:value-of select="jakartaee:name"/>
       </xsl:element>
       <br/>
     </xsl:template>
@@ -92,11 +93,11 @@
       - Same as above, but add the () to indicate it's a function 
       - and change the HTML to .fn.html
       -->
-    <xsl:template match="javaee:function">
+    <xsl:template match="jakartaee:function">
       <xsl:element name="a">
-        <xsl:attribute name="href"><xsl:value-of select="../javaee:short-name"/>/<xsl:value-of select="javaee:name"/>.fn.html</xsl:attribute>
+        <xsl:attribute name="href"><xsl:value-of select="../jakartaee:short-name"/>/<xsl:value-of select="jakartaee:name"/>.fn.html</xsl:attribute>
         <xsl:attribute name="target">tagFrame</xsl:attribute>
-        <i><xsl:value-of select="../javaee:short-name"/>:<xsl:value-of select="javaee:name"/>()</i>
+        <i><xsl:value-of select="../jakartaee:short-name"/>:<xsl:value-of select="jakartaee:name"/>()</i>
       </xsl:element>
       <br/>
     </xsl:template>

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/alltags-noframe.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/alltags-noframe.html.xsl
@@ -3,6 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
+  - Copyright (c) 2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 
@@ -41,7 +42,7 @@
 -->
 
 <xsl:stylesheet version="1.0"
-    xmlns:javaee="http://java.sun.com/xml/ns/javaee" 
+    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee" 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format">
     
@@ -68,9 +69,9 @@
             <tr>
               <td nowrap="true"><font class="FrameItemFont">
                 <xsl:apply-templates 
-                    select="javaee:tlds/javaee:taglib/javaee:tag|javaee:tlds/javaee:taglib/javaee:tag-file|javaee:tlds/javaee:taglib/javaee:function">
-                  <xsl:sort select="../javaee:short-name"/>
-                  <xsl:sort select="javaee:name"/>
+                    select="jakartaee:tlds/jakartaee:taglib/jakartaee:tag|jakartaee:tlds/jakartaee:taglib/jakartaee:tag-file|jakartaee:tlds/jakartaee:taglib/jakartaee:function">
+                  <xsl:sort select="../jakartaee:short-name"/>
+                  <xsl:sort select="jakartaee:name"/>
                 </xsl:apply-templates>
               </font></td>
             </tr>
@@ -79,11 +80,11 @@
       </html>    
     </xsl:template>
     
-    <xsl:template match="javaee:tag|javaee:tag-file">
+    <xsl:template match="jakartaee:tag|jakartaee:tag-file">
       <xsl:element name="a">
-        <xsl:attribute name="href"><xsl:value-of select="../javaee:short-name"/>/<xsl:value-of select="javaee:name"/>.html</xsl:attribute>
+        <xsl:attribute name="href"><xsl:value-of select="../jakartaee:short-name"/>/<xsl:value-of select="jakartaee:name"/>.html</xsl:attribute>
         <xsl:attribute name="target"></xsl:attribute>
-        <xsl:value-of select="../javaee:short-name"/>:<xsl:value-of select="javaee:name"/>
+        <xsl:value-of select="../jakartaee:short-name"/>:<xsl:value-of select="jakartaee:name"/>
       </xsl:element>
       <br/>
     </xsl:template>
@@ -92,11 +93,11 @@
       - Same as above, but add the () to indicate it's a function 
       - and change the HTML to .fn.html
       -->
-    <xsl:template match="javaee:function">
+    <xsl:template match="jakartaee:function">
       <xsl:element name="a">
-        <xsl:attribute name="href"><xsl:value-of select="../javaee:short-name"/>/<xsl:value-of select="javaee:name"/>.fn.html</xsl:attribute>
+        <xsl:attribute name="href"><xsl:value-of select="../jakartaee:short-name"/>/<xsl:value-of select="jakartaee:name"/>.fn.html</xsl:attribute>
         <xsl:attribute name="target">tagFrame</xsl:attribute>
-        <i><xsl:value-of select="../javaee:short-name"/>:<xsl:value-of select="javaee:name"/>()</i>
+        <i><xsl:value-of select="../jakartaee:short-name"/>:<xsl:value-of select="jakartaee:name"/>()</i>
       </xsl:element>
       <br/>
     </xsl:template>

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/alltags-noframe.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/alltags-noframe.html.xsl
@@ -3,7 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
-  - Copyright (c) 2022 Contributors to the Eclipse Foundation
+  - Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/function.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/function.html.xsl
@@ -42,7 +42,7 @@
 -->
 
 <xsl:stylesheet version="1.0"
-    xmlns:javaee="http://java.sun.com/xml/ns/javaee" 
+    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee" 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format">
     
@@ -53,24 +53,24 @@
 
     <!-- template rule matching source root element -->
     <xsl:template match="/">
-      <xsl:apply-templates select="javaee:tlds/javaee:taglib"/>
+      <xsl:apply-templates select="jakartaee:tlds/jakartaee:taglib"/>
     </xsl:template>
     
-    <xsl:template match="javaee:taglib">
-      <xsl:if test="javaee:short-name=$tlddoc-shortName">
-        <xsl:apply-templates select="javaee:function"/>
+    <xsl:template match="jakartaee:taglib">
+      <xsl:if test="jakartaee:short-name=$tlddoc-shortName">
+        <xsl:apply-templates select="jakartaee:function"/>
       </xsl:if>
     </xsl:template>
     
-    <xsl:template match="javaee:function">
-      <xsl:if test="javaee:name=$tlddoc-functionName">
+    <xsl:template match="jakartaee:function">
+      <xsl:if test="jakartaee:name=$tlddoc-functionName">
         <xsl:variable name="tldname">
           <xsl:choose>
-            <xsl:when test="../javaee:display-name!=''">
-              <xsl:value-of select="../javaee:display-name"/>
+            <xsl:when test="../jakartaee:display-name!=''">
+              <xsl:value-of select="../jakartaee:display-name"/>
             </xsl:when>
-            <xsl:when test="../javaee:short-name!=''">
-              <xsl:value-of select="../javaee:short-name"/>
+            <xsl:when test="../jakartaee:short-name!=''">
+              <xsl:value-of select="../jakartaee:short-name"/>
             </xsl:when>
             <xsl:otherwise>
               Unnamed TLD
@@ -78,8 +78,8 @@
           </xsl:choose>
         </xsl:variable>
         <xsl:variable name="title">
-          <xsl:value-of select="javaee:name"/>
-          (<xsl:value-of select="/javaee:tlds/javaee:config/javaee:window-title"/>)
+          <xsl:value-of select="jakartaee:name"/>
+          (<xsl:value-of select="/jakartaee:tlds/jakartaee:config/jakartaee:window-title"/>)
         </xsl:variable>
         <html>
           <head>
@@ -122,7 +122,7 @@
               <td BGCOLOR="white" CLASS="NavBarCell2"><font SIZE="-2">
                 &#160;<a HREF="../index.html" TARGET="_top"><b>FRAMES</b></a>&#160;
                 &#160;<xsl:element name="a">
-                  <xsl:attribute name="href"><xsl:value-of select="javaee:name"/>.fn.html</xsl:attribute>
+                  <xsl:attribute name="href"><xsl:value-of select="jakartaee:name"/>.fn.html</xsl:attribute>
                   <xsl:attribute name="target">_top</xsl:attribute>
                   <b>NO FRAMES</b>
                 </xsl:element>&#160;
@@ -143,19 +143,19 @@
             
             <hr/>
             <h2><font size="-1"><xsl:value-of select="$tldname"/></font><br/>
-            Function <xsl:value-of select="javaee:name"/></h2>
+            Function <xsl:value-of select="jakartaee:name"/></h2>
             <code>
-              <xsl:value-of select='substring-before(normalize-space(javaee:function-signature)," ")'/>
-              <b>&#160;<xsl:value-of select="javaee:name"/></b>(<xsl:value-of 
-              select='substring-after(normalize-space(javaee:function-signature),"(")'/>
+              <xsl:value-of select='substring-before(normalize-space(jakartaee:function-signature)," ")'/>
+              <b>&#160;<xsl:value-of select="jakartaee:name"/></b>(<xsl:value-of 
+              select='substring-after(normalize-space(jakartaee:function-signature),"(")'/>
             </code>
             <hr/>
-            <xsl:value-of select="javaee:description" disable-output-escaping="yes"/><br/>
+            <xsl:value-of select="jakartaee:description" disable-output-escaping="yes"/><br/>
             <p/>
-            <xsl:if test="javaee:example!=''">
+            <xsl:if test="jakartaee:example!=''">
               <b>Example:</b><br/>
               <pre>
-<xsl:value-of select="javaee:example"/>              
+<xsl:value-of select="jakartaee:example"/>              
               </pre>
               <p/>
             </xsl:if>
@@ -174,8 +174,8 @@
                 <td>Function Class</td>
                 <td>
                   <xsl:choose>
-                    <xsl:when test="javaee:function-class!=''">
-                      <xsl:value-of select="javaee:function-class"/>
+                    <xsl:when test="jakartaee:function-class!=''">
+                      <xsl:value-of select="jakartaee:function-class"/>
                     </xsl:when>
                     <xsl:otherwise>
                       <i>None</i>
@@ -187,8 +187,8 @@
                 <td>Function Signature</td>
                 <td>
                   <xsl:choose>
-                    <xsl:when test="javaee:function-signature!=''">
-                      <xsl:value-of select="javaee:function-signature"/>
+                    <xsl:when test="jakartaee:function-signature!=''">
+                      <xsl:value-of select="jakartaee:function-signature"/>
                     </xsl:when>
                     <xsl:otherwise>
                       <i>None</i>
@@ -200,8 +200,8 @@
                 <td>Display Name</td>
                 <td>
                   <xsl:choose>
-                    <xsl:when test="javaee:display-name!=''">
-                      <xsl:value-of select="javaee:display-name"/>
+                    <xsl:when test="jakartaee:display-name!=''">
+                      <xsl:value-of select="jakartaee:display-name"/>
                     </xsl:when>
                     <xsl:otherwise>
                       <i>None</i>
@@ -240,7 +240,7 @@
               <td BGCOLOR="white" CLASS="NavBarCell2"><font SIZE="-2">
                 &#160;<a HREF="../index.html" TARGET="_top"><b>FRAMES</b></a>&#160;
                 &#160;<xsl:element name="a">
-                  <xsl:attribute name="href"><xsl:value-of select="javaee:name"/>.fn.html</xsl:attribute>
+                  <xsl:attribute name="href"><xsl:value-of select="jakartaee:name"/>.fn.html</xsl:attribute>
                   <xsl:attribute name="target">_top</xsl:attribute>
                   <b>NO FRAMES</b>
                 </xsl:element>&#160;

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/help-doc.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/help-doc.html.xsl
@@ -41,7 +41,7 @@
 -->
 
 <xsl:stylesheet version="1.0"
-    xmlns:javaee="http://java.sun.com/xml/ns/javaee" 
+    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee" 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format">
     
@@ -52,13 +52,13 @@
       <HTML>
         <HEAD>
           <TITLE>
-            API Help (<xsl:value-of select="/javaee:tlds/javaee:config/javaee:window-title"/>)
+            API Help (<xsl:value-of select="/jakartaee:tlds/jakartaee:config/jakartaee:window-title"/>)
           </TITLE>
           <LINK REL ="stylesheet" TYPE="text/css" HREF="stylesheet.css" TITLE="Style"/>
         </HEAD>
         <SCRIPT>
           function asd() {
-            parent.document.title="API Help (<xsl:value-of select="normalize-space(/javaee:tlds/javaee:config/javaee:window-title)"/>)";
+            parent.document.title="API Help (<xsl:value-of select="normalize-space(/jakartaee:tlds/jakartaee:config/jakartaee:window-title)"/>)";
           }
         </SCRIPT>
         <BODY BGCOLOR="white" onload="asd();">

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/index.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/index.html.xsl
@@ -3,7 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
-  - Copyright (c) 2022 Contributors to the Eclipse Foundation
+  - Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/index.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/index.html.xsl
@@ -3,6 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
+  - Copyright (c) 2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 
@@ -40,7 +41,7 @@
 -->
 
 <xsl:stylesheet version="1.0"
-    xmlns:javaee="http://java.sun.com/xml/ns/javaee" 
+    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee" 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format">
     
@@ -51,7 +52,7 @@
       <html>
         <head>
           <title>
-            <xsl:value-of select="/javaee:tlds/javaee:config/javaee:window-title"/>
+            <xsl:value-of select="/jakartaee:tlds/jakartaee:config/jakartaee:window-title"/>
           </title>
         </head>
         <frameset cols="20%,80%">

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/overview-frame.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/overview-frame.html.xsl
@@ -3,7 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
-  - Copyright (c) 2022 Contributors to the Eclipse Foundation
+  - Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/overview-frame.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/overview-frame.html.xsl
@@ -3,6 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
+  - Copyright (c) 2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 
@@ -43,7 +44,7 @@
 <xsl:stylesheet version="1.0"
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format"
-    xmlns:javaee="http://java.sun.com/xml/ns/javaee">
+    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee">
     
     <xsl:output method="html" indent="yes"/>
 
@@ -52,13 +53,13 @@
       <html>
         <head>
           <title>
-            Overview (<xsl:value-of select="/javaee:tlds/javaee:config/javaee:window-title"/>)
+            Overview (<xsl:value-of select="/jakartaee:tlds/jakartaee:config/jakartaee:window-title"/>)
           </title>
           <link rel="stylesheet" type="text/css" href="stylesheet.css" title="Style"/>
         </head>
         <script>
           function asd() {
-            parent.document.title="Overview (<xsl:value-of select="normalize-space(/javaee:tlds/javaee:config/javaee:window-title)"/>)";
+            parent.document.title="Overview (<xsl:value-of select="normalize-space(/jakartaee:tlds/jakartaee:config/jakartaee:window-title)"/>)";
           }
         </script>
         <body bgcolor="white" onload="asd();">
@@ -66,7 +67,7 @@
             <tr>
               <td nowrap="true">
                 <font size="+1" class="FrameTitleFont">
-                  <b><xsl:value-of select="/javaee:tlds/javaee:config/javaee:doc-title"/></b>
+                  <b><xsl:value-of select="/jakartaee:tlds/jakartaee:config/jakartaee:doc-title"/></b>
                 </font>
               </td>
             </tr>
@@ -82,7 +83,7 @@
                   Tag Libraries
                 </font>
                 <br/>
-                <xsl:apply-templates select="javaee:tlds/javaee:taglib"/>
+                <xsl:apply-templates select="jakartaee:tlds/jakartaee:taglib"/>
               </td>
             </tr>
           </table>
@@ -91,17 +92,17 @@
       </html>
     </xsl:template>
     
-    <xsl:template match="javaee:taglib">
+    <xsl:template match="jakartaee:taglib">
       <font class="FrameItemFont">
         <xsl:element name="a">
-          <xsl:attribute name="href"><xsl:value-of select="javaee:short-name"/>/tld-frame.html</xsl:attribute>
+          <xsl:attribute name="href"><xsl:value-of select="jakartaee:short-name"/>/tld-frame.html</xsl:attribute>
           <xsl:attribute name="target">tldFrame</xsl:attribute>
           <xsl:choose>
-            <xsl:when test="javaee:display-name!=''">
-              <xsl:value-of select="javaee:display-name"/>
+            <xsl:when test="jakartaee:display-name!=''">
+              <xsl:value-of select="jakartaee:display-name"/>
             </xsl:when>
-            <xsl:when test="javaee:short-name!=''">
-              <xsl:value-of select="javaee:short-name"/>
+            <xsl:when test="jakartaee:short-name!=''">
+              <xsl:value-of select="jakartaee:short-name"/>
             </xsl:when>
             <xsl:otherwise>
               Unnamed TLD

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/overview-summary.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/overview-summary.html.xsl
@@ -42,7 +42,7 @@
 -->
 
 <xsl:stylesheet version="1.0"
-    xmlns:javaee="http://java.sun.com/xml/ns/javaee" 
+    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee" 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format">
     
@@ -53,13 +53,13 @@
       <html>
         <head>
           <title>
-            Overview (<xsl:value-of select="/javaee:tlds/javaee:config/javaee:window-title"/>)
+            Overview (<xsl:value-of select="/jakartaee:tlds/jakartaee:config/jakartaee:window-title"/>)
           </title>
           <link rel="stylesheet" type="text/css" href="stylesheet.css" title="Style"/>
         </head>
         <script>
           function asd() {
-            parent.document.title="Overview (<xsl:value-of select="normalize-space(/javaee:tlds/javaee:config/javaee:window-title)"/>)";
+            parent.document.title="Overview (<xsl:value-of select="normalize-space(/jakartaee:tlds/jakartaee:config/jakartaee:window-title)"/>)";
           }
         </script>
         <body bgcolor="white" onload="asd();">
@@ -106,7 +106,7 @@
           <!-- =========== END OF NAVBAR =========== -->
           <hr/>
           <center>
-            <h2><xsl:value-of select="/javaee:tlds/javaee:config/javaee:doc-title"/></h2>
+            <h2><xsl:value-of select="/jakartaee:tlds/jakartaee:config/jakartaee:doc-title"/></h2>
           </center>
           <table BORDER="1" CELLPADDING="3" CELLSPACING="0" WIDTH="100%">
             <tr BGCOLOR="#CCCCFF" CLASS="TableHeadingColor">
@@ -114,7 +114,7 @@
                 <b>Tag Libraries</b>
               </font></td>
             </tr>
-            <xsl:apply-templates select="/javaee:tlds/javaee:taglib"/>
+            <xsl:apply-templates select="/jakartaee:tlds/jakartaee:taglib"/>
           </table>
           <p/>
           <hr/>
@@ -167,17 +167,17 @@
       </html>
     </xsl:template>
     
-    <xsl:template match="javaee:taglib">
+    <xsl:template match="jakartaee:taglib">
       <tr BGCOLOR="white" valign="top" CLASS="TableRowColor">
         <td WIDTH="20%"><b>
           <xsl:element name="a">
-            <xsl:attribute name="href"><xsl:value-of select="javaee:short-name"/>/tld-summary.html</xsl:attribute>
+            <xsl:attribute name="href"><xsl:value-of select="jakartaee:short-name"/>/tld-summary.html</xsl:attribute>
             <xsl:choose>
-              <xsl:when test="javaee:display-name!=''">
-                <xsl:value-of select="javaee:display-name"/>
+              <xsl:when test="jakartaee:display-name!=''">
+                <xsl:value-of select="jakartaee:display-name"/>
               </xsl:when>
-              <xsl:when test="javaee:short-name!=''">
-                <xsl:value-of select="javaee:short-name"/>
+              <xsl:when test="jakartaee:short-name!=''">
+                <xsl:value-of select="jakartaee:short-name"/>
               </xsl:when>
               <xsl:otherwise>
                 Unnamed TLD
@@ -187,9 +187,9 @@
         </b></td>
         <td>
           <xsl:choose>
-              <xsl:when test="javaee:description!=''">
+              <xsl:when test="jakartaee:description!=''">
                 <pre>
-                  <xsl:value-of select="javaee:description" disable-output-escaping="yes"/>
+                  <xsl:value-of select="jakartaee:description" disable-output-escaping="yes"/>
                 </pre>
               </xsl:when>
               <xsl:otherwise>

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tag.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tag.html.xsl
@@ -354,11 +354,7 @@
           <xsl:choose>
             <xsl:when test="jakartaee:deferred-value">
                 <xsl:choose>
-<<<<<<< HEAD
-                    <xsl:when test="javaee:deferred-value/javaee:type">
-=======
                     <xsl:when test="jakartaee:deferred-value/jakartaee:type">
->>>>>>> Update xsl stylesheets to jakartaee
                         <code>jakarta.el.ValueExpression</code>
                         <br/>(<i>must evaluate to </i><code><xsl:value-of
                                 select="jakartaee:deferred-value/jakartaee:type"/></code>)
@@ -371,11 +367,7 @@
             </xsl:when>
             <xsl:when test="jakartaee:deferred-method">
                 <xsl:choose>
-<<<<<<< HEAD
-                    <xsl:when test="javaee:deferred-method/javaee:method-signature">
-=======
                     <xsl:when test="jakartaee:deferred-method/jakartaee:method-signature">
->>>>>>> Update xsl stylesheets to jakartaee
                         <code>jakarta.el.MethodExpression</code>
                         <br/>(<i>signature must match </i><code><xsl:value-of
                                 select="jakartaee:deferred-method/jakartaee:method-signature"/></code>)

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tag.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tag.html.xsl
@@ -42,7 +42,7 @@
 -->
 
 <xsl:stylesheet version="1.0"
-    xmlns:javaee="http://java.sun.com/xml/ns/javaee" 
+    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee" 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format">
     
@@ -53,24 +53,24 @@
 
     <!-- template rule matching source root element -->
     <xsl:template match="/">
-      <xsl:apply-templates select="javaee:tlds/javaee:taglib"/>
+      <xsl:apply-templates select="jakartaee:tlds/jakartaee:taglib"/>
     </xsl:template>
     
-    <xsl:template match="javaee:taglib">
-      <xsl:if test="javaee:short-name=$tlddoc-shortName">
-        <xsl:apply-templates select="javaee:tag|javaee:tag-file"/>
+    <xsl:template match="jakartaee:taglib">
+      <xsl:if test="jakartaee:short-name=$tlddoc-shortName">
+        <xsl:apply-templates select="jakartaee:tag|jakartaee:tag-file"/>
       </xsl:if>
     </xsl:template>
     
-    <xsl:template match="javaee:tag|javaee:tag-file">
-      <xsl:if test="javaee:name=$tlddoc-tagName">
+    <xsl:template match="jakartaee:tag|jakartaee:tag-file">
+      <xsl:if test="jakartaee:name=$tlddoc-tagName">
         <xsl:variable name="tldname">
           <xsl:choose>
-            <xsl:when test="../javaee:display-name!=''">
-              <xsl:value-of select="../javaee:display-name"/>
+            <xsl:when test="../jakartaee:display-name!=''">
+              <xsl:value-of select="../jakartaee:display-name"/>
             </xsl:when>
-            <xsl:when test="../javaee:short-name!=''">
-              <xsl:value-of select="../javaee:short-name"/>
+            <xsl:when test="../jakartaee:short-name!=''">
+              <xsl:value-of select="../jakartaee:short-name"/>
             </xsl:when>
             <xsl:otherwise>
               Unnamed TLD
@@ -78,8 +78,8 @@
           </xsl:choose>
         </xsl:variable>
         <xsl:variable name="title">
-          <xsl:value-of select="javaee:name"/>
-          (<xsl:value-of select="/javaee:tlds/javaee:config/javaee:window-title"/>)
+          <xsl:value-of select="jakartaee:name"/>
+          (<xsl:value-of select="/jakartaee:tlds/jakartaee:config/jakartaee:window-title"/>)
         </xsl:variable>
         <html>
           <head>
@@ -122,7 +122,7 @@
               <td BGCOLOR="white" CLASS="NavBarCell2"><font SIZE="-2">
                 &#160;<a HREF="../index.html" TARGET="_top"><b>FRAMES</b></a>&#160;
                 &#160;<xsl:element name="a">
-                  <xsl:attribute name="href"><xsl:value-of select="javaee:name"/>.html</xsl:attribute>
+                  <xsl:attribute name="href"><xsl:value-of select="jakartaee:name"/>.html</xsl:attribute>
                   <xsl:attribute name="target">_top</xsl:attribute>
                   <b>NO FRAMES</b>
                 </xsl:element>&#160;
@@ -143,14 +143,14 @@
             
             <hr/>
             <h2><font size="-1"><xsl:value-of select="$tldname"/></font><br/>
-            Tag <xsl:value-of select="javaee:name"/></h2>
+            Tag <xsl:value-of select="jakartaee:name"/></h2>
             <hr/>
-            <xsl:value-of select="javaee:description" disable-output-escaping="yes"/><br/>
+            <xsl:value-of select="jakartaee:description" disable-output-escaping="yes"/><br/>
             <p/>
-            <xsl:if test="javaee:example!=''">
+            <xsl:if test="jakartaee:example!=''">
               <b>Example:</b><br/>
               <pre>
-<xsl:value-of select="javaee:example"/>              
+<xsl:value-of select="jakartaee:example"/>              
               </pre>
               <p/>
             </xsl:if>
@@ -169,8 +169,8 @@
                 <td>Tag Class</td>
                 <td>
                   <xsl:choose>
-                    <xsl:when test="javaee:tag-class!=''">
-                      <xsl:value-of select="javaee:tag-class"/>
+                    <xsl:when test="jakartaee:tag-class!=''">
+                      <xsl:value-of select="jakartaee:tag-class"/>
                     </xsl:when>
                     <xsl:otherwise>
                       <i>None</i>
@@ -182,8 +182,8 @@
                 <td>TagExtraInfo Class</td>
                 <td>
                   <xsl:choose>
-                    <xsl:when test="javaee:tei-class!=''">
-                      <xsl:value-of select="javaee:tei-class"/>
+                    <xsl:when test="jakartaee:tei-class!=''">
+                      <xsl:value-of select="jakartaee:tei-class"/>
                     </xsl:when>
                     <xsl:otherwise>
                       <i>None</i>
@@ -195,8 +195,8 @@
                 <td>Body Content</td>
                 <td>
                   <xsl:choose>
-                    <xsl:when test="javaee:body-content!=''">
-                      <xsl:value-of select="javaee:body-content"/>
+                    <xsl:when test="jakartaee:body-content!=''">
+                      <xsl:value-of select="jakartaee:body-content"/>
                     </xsl:when>
                     <xsl:otherwise>
                       <i>None</i>
@@ -208,8 +208,8 @@
                 <td>Display Name</td>
                 <td>
                   <xsl:choose>
-                    <xsl:when test="javaee:display-name!=''">
-                      <xsl:value-of select="javaee:display-name"/>
+                    <xsl:when test="jakartaee:display-name!=''">
+                      <xsl:value-of select="jakartaee:display-name"/>
                     </xsl:when>
                     <xsl:otherwise>
                       <i>None</i>
@@ -231,7 +231,7 @@
                 </td>
               </tr>
               <xsl:choose>
-                <xsl:when test="count(javaee:attribute)>0">
+                <xsl:when test="count(jakartaee:attribute)>0">
                   <tr>
                     <td><b>Name</b></td>
                     <td><b>Required</b></td>
@@ -239,7 +239,7 @@
                     <td><b>Type</b></td>
                     <td><b>Description</b></td>
                   </tr>
-                  <xsl:apply-templates select="javaee:attribute"/>
+                  <xsl:apply-templates select="jakartaee:attribute"/>
                 </xsl:when>
                 <xsl:otherwise>
                   <td colspan="5"><i>No Attributes Defined.</i></td>
@@ -259,7 +259,7 @@
                 </td>
               </tr>
               <xsl:choose>
-                <xsl:when test="count(javaee:variable)>0">
+                <xsl:when test="count(jakartaee:variable)>0">
                   <tr>
                     <td><b>Name</b></td>
                     <td><b>Type</b></td>
@@ -267,7 +267,7 @@
                     <td><b>Scope</b></td>
                     <td><b>Description</b></td>
                   </tr>
-                  <xsl:apply-templates select="javaee:variable"/>
+                  <xsl:apply-templates select="jakartaee:variable"/>
                 </xsl:when>
                 <xsl:otherwise>
                   <td colspan="2"><i>No Variables Defined.</i></td>
@@ -304,7 +304,7 @@
               <td BGCOLOR="white" CLASS="NavBarCell2"><font SIZE="-2">
                 &#160;<a HREF="../index.html" TARGET="_top"><b>FRAMES</b></a>&#160;
                 &#160;<xsl:element name="a">
-                  <xsl:attribute name="href"><xsl:value-of select="javaee:name"/>.html</xsl:attribute>
+                  <xsl:attribute name="href"><xsl:value-of select="jakartaee:name"/>.html</xsl:attribute>
                   <xsl:attribute name="target">_top</xsl:attribute>
                   <b>NO FRAMES</b>
                 </xsl:element>&#160;
@@ -331,33 +331,37 @@
       </xsl:if>
     </xsl:template>
 
-    <xsl:template match="javaee:attribute">
+    <xsl:template match="jakartaee:attribute">
       <tr valign="top">
-        <td><xsl:apply-templates select="javaee:name"/></td>
+        <td><xsl:apply-templates select="jakartaee:name"/></td>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:required!=''">
-              <xsl:value-of select="javaee:required"/>
+            <xsl:when test="jakartaee:required!=''">
+              <xsl:value-of select="jakartaee:required"/>
             </xsl:when>
             <xsl:otherwise>false</xsl:otherwise>
           </xsl:choose>
         </td>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:rtexprvalue!=''">
-              <xsl:value-of select="javaee:rtexprvalue"/>
+            <xsl:when test="jakartaee:rtexprvalue!=''">
+              <xsl:value-of select="jakartaee:rtexprvalue"/>
             </xsl:when>
             <xsl:otherwise>false</xsl:otherwise>
           </xsl:choose>
         </td>        
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:deferred-value">
+            <xsl:when test="jakartaee:deferred-value">
                 <xsl:choose>
+<<<<<<< HEAD
                     <xsl:when test="javaee:deferred-value/javaee:type">
+=======
+                    <xsl:when test="jakartaee:deferred-value/jakartaee:type">
+>>>>>>> Update xsl stylesheets to jakartaee
                         <code>jakarta.el.ValueExpression</code>
                         <br/>(<i>must evaluate to </i><code><xsl:value-of
-                                select="javaee:deferred-value/javaee:type"/></code>)
+                                select="jakartaee:deferred-value/jakartaee:type"/></code>)
                     </xsl:when>
                     <xsl:otherwise>
                         <code>jakarta.el.ValueExpression</code>
@@ -365,12 +369,16 @@
                     </xsl:otherwise>
                 </xsl:choose>                                
             </xsl:when>
-            <xsl:when test="javaee:deferred-method">
+            <xsl:when test="jakartaee:deferred-method">
                 <xsl:choose>
+<<<<<<< HEAD
                     <xsl:when test="javaee:deferred-method/javaee:method-signature">
+=======
+                    <xsl:when test="jakartaee:deferred-method/jakartaee:method-signature">
+>>>>>>> Update xsl stylesheets to jakartaee
                         <code>jakarta.el.MethodExpression</code>
                         <br/>(<i>signature must match </i><code><xsl:value-of
-                                select="javaee:deferred-method/javaee:method-signature"/></code>)
+                                select="jakartaee:deferred-method/jakartaee:method-signature"/></code>)
                     </xsl:when>
                     <xsl:otherwise>
                         <code>jakarta.el.MethodExpression</code>
@@ -378,8 +386,8 @@
                     </xsl:otherwise>
                 </xsl:choose>
             </xsl:when>
-            <xsl:when test="javaee:type!=''">
-              <code><xsl:value-of select="javaee:type"/></code>
+            <xsl:when test="jakartaee:type!=''">
+              <code><xsl:value-of select="jakartaee:type"/></code>
             </xsl:when>
             <xsl:otherwise>
                 <code>java.lang.String</code>                
@@ -388,8 +396,8 @@
         </td>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:description!=''">
-              <xsl:value-of select="javaee:description" disable-output-escaping="yes"/>
+            <xsl:when test="jakartaee:description!=''">
+              <xsl:value-of select="jakartaee:description" disable-output-escaping="yes"/>
             </xsl:when>
             <xsl:otherwise><i>No Description</i></xsl:otherwise>
           </xsl:choose>
@@ -397,15 +405,15 @@
       </tr>
     </xsl:template>
     
-    <xsl:template match="javaee:variable">
+    <xsl:template match="jakartaee:variable">
       <tr>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:name-given!=''">
-              <xsl:value-of select="javaee:name-given"/>
+            <xsl:when test="jakartaee:name-given!=''">
+              <xsl:value-of select="jakartaee:name-given"/>
             </xsl:when>
-            <xsl:when test="javaee:name-from-attribute!=''">
-              <i>From attribute '<xsl:value-of select="javaee:name-from-attribute"/>'</i>
+            <xsl:when test="jakartaee:name-from-attribute!=''">
+              <i>From attribute '<xsl:value-of select="jakartaee:name-from-attribute"/>'</i>
             </xsl:when>
             <xsl:otherwise>
               <i>Unknown</i>
@@ -414,32 +422,32 @@
         </td>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:variable-class!=''">
-              <code><xsl:value-of select="javaee:variable-class"/></code>
+            <xsl:when test="jakartaee:variable-class!=''">
+              <code><xsl:value-of select="jakartaee:variable-class"/></code>
             </xsl:when>
             <xsl:otherwise><code>java.lang.String</code></xsl:otherwise>
           </xsl:choose>
         </td>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:declare!=''">
-              <xsl:value-of select="javaee:declare"/>
+            <xsl:when test="jakartaee:declare!=''">
+              <xsl:value-of select="jakartaee:declare"/>
             </xsl:when>
             <xsl:otherwise>true</xsl:otherwise>
           </xsl:choose>
         </td>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:scope!=''">
-              <xsl:value-of select="javaee:scope"/>
+            <xsl:when test="jakartaee:scope!=''">
+              <xsl:value-of select="jakartaee:scope"/>
             </xsl:when>
             <xsl:otherwise>NESTED</xsl:otherwise>
           </xsl:choose>
         </td>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:description!=''">
-              <xsl:value-of select="javaee:description" disable-output-escaping="yes"/>
+            <xsl:when test="jakartaee:description!=''">
+              <xsl:value-of select="jakartaee:description" disable-output-escaping="yes"/>
             </xsl:when>
             <xsl:otherwise><i>No Description</i></xsl:otherwise>
           </xsl:choose>

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tld-frame.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tld-frame.html.xsl
@@ -3,6 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
+  - Copyright (c) 2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 
@@ -41,7 +42,7 @@
 -->
 
 <xsl:stylesheet version="1.0"
-    xmlns:javaee="http://java.sun.com/xml/ns/javaee" 
+    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee" 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format">
     
@@ -51,18 +52,18 @@
 
     <!-- template rule matching source root element -->
     <xsl:template match="/">
-      <xsl:apply-templates select="javaee:tlds/javaee:taglib"/>
+      <xsl:apply-templates select="jakartaee:tlds/jakartaee:taglib"/>
     </xsl:template>
     
-    <xsl:template match="javaee:taglib">
-      <xsl:if test="javaee:short-name=$tlddoc-shortName">
+    <xsl:template match="jakartaee:taglib">
+      <xsl:if test="jakartaee:short-name=$tlddoc-shortName">
         <xsl:variable name="tldname">
           <xsl:choose>
-            <xsl:when test="javaee:display-name!=''">
-              <xsl:value-of select="javaee:display-name"/>
+            <xsl:when test="jakartaee:display-name!=''">
+              <xsl:value-of select="jakartaee:display-name"/>
             </xsl:when>
-            <xsl:when test="javaee:short-name!=''">
-              <xsl:value-of select="javaee:short-name"/>
+            <xsl:when test="jakartaee:short-name!=''">
+              <xsl:value-of select="jakartaee:short-name"/>
             </xsl:when>
             <xsl:otherwise>
               Unnamed TLD
@@ -72,8 +73,8 @@
         <xsl:variable name="tldfull">
           <xsl:value-of select="$tldname"/>
           <xsl:choose>
-            <xsl:when test="javaee:description!=''">
-              (<xsl:value-of select="javaee:description" disable-output-escaping="yes"/>)
+            <xsl:when test="jakartaee:description!=''">
+              (<xsl:value-of select="jakartaee:description" disable-output-escaping="yes"/>)
             </xsl:when>
             <xsl:otherwise>
               No Description
@@ -102,50 +103,50 @@
               </a>
             </font>
             <table border="0" width="100%">
-              <xsl:if test="(count(javaee:tag)+count(javaee:tag-file))>0">
+              <xsl:if test="(count(jakartaee:tag)+count(jakartaee:tag-file))>0">
                 <tr>
                   <td nowrap="true">
                     <font size="+1" class="FrameHeadingFont">
                       Tags
                     </font>&#160;
                     <font class="FrameItemFont">
-                      <xsl:apply-templates select="javaee:tag|javaee:tag-file"/>
+                      <xsl:apply-templates select="jakartaee:tag|jakartaee:tag-file"/>
                     </font>
                   </td>
                 </tr>
               </xsl:if>
-              <xsl:if test="count(javaee:function)>0">
+              <xsl:if test="count(jakartaee:function)>0">
                 <tr>
                   <td nowrap="true">
                     <font size="+1" class="FrameHeadingFont">
                       Functions
                     </font>&#160;
                     <font class="FrameItemFont">
-                      <xsl:apply-templates select="javaee:function"/>
+                      <xsl:apply-templates select="jakartaee:function"/>
                     </font>
                   </td>
                 </tr>
               </xsl:if>
-              <xsl:if test="count(javaee:validator)>0">
+              <xsl:if test="count(jakartaee:validator)>0">
                 <tr>
                   <td nowrap="true">
                     <font size="+1" class="FrameHeadingFont">
                       Validator
                     </font>&#160;
                     <font class="FrameItemFont">
-                      <xsl:apply-templates select="javaee:validator"/>
+                      <xsl:apply-templates select="jakartaee:validator"/>
                     </font>
                   </td>
                 </tr>
               </xsl:if>
-              <xsl:if test="count(javaee:listener)>0">
+              <xsl:if test="count(jakartaee:listener)>0">
                 <tr>
                   <td nowrap="true">
                     <font size="+1" class="FrameHeadingFont">
                       Listeners
                     </font>&#160;
                     <font class="FrameItemFont">
-                      <xsl:apply-templates select="javaee:listener"/>
+                      <xsl:apply-templates select="jakartaee:listener"/>
                     </font>
                   </td>
                 </tr>
@@ -157,32 +158,32 @@
       </xsl:if>
     </xsl:template>
     
-    <xsl:template match="javaee:tag|javaee:tag-file">
+    <xsl:template match="jakartaee:tag|jakartaee:tag-file">
       <br/>
       <xsl:element name="a">
-        <xsl:attribute name="href"><xsl:value-of select="javaee:name"/>.html</xsl:attribute>
+        <xsl:attribute name="href"><xsl:value-of select="jakartaee:name"/>.html</xsl:attribute>
         <xsl:attribute name="target">tagFrame</xsl:attribute>
-        <xsl:value-of select="../javaee:short-name"/>:<xsl:value-of select="javaee:name"/>
+        <xsl:value-of select="../jakartaee:short-name"/>:<xsl:value-of select="jakartaee:name"/>
       </xsl:element>
     </xsl:template>
     
-    <xsl:template match="javaee:function">
+    <xsl:template match="jakartaee:function">
       <br/>
       <xsl:element name="a">
-        <xsl:attribute name="href"><xsl:value-of select="javaee:name"/>.fn.html</xsl:attribute>
+        <xsl:attribute name="href"><xsl:value-of select="jakartaee:name"/>.fn.html</xsl:attribute>
         <xsl:attribute name="target">tagFrame</xsl:attribute>
-        <i><xsl:value-of select="../javaee:short-name"/>:<xsl:value-of select="javaee:name"/>()</i>
+        <i><xsl:value-of select="../jakartaee:short-name"/>:<xsl:value-of select="jakartaee:name"/>()</i>
       </xsl:element>
     </xsl:template>
     
-    <xsl:template match="javaee:validator">
+    <xsl:template match="jakartaee:validator">
       <br/>
-      <xsl:value-of select="javaee:validator-class"/>
+      <xsl:value-of select="jakartaee:validator-class"/>
     </xsl:template>
     
-    <xsl:template match="javaee:listener">
+    <xsl:template match="jakartaee:listener">
       <br/>
-      <xsl:value-of select="javaee:listener-class"/>
+      <xsl:value-of select="jakartaee:listener-class"/>
     </xsl:template>
     
 </xsl:stylesheet> 

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tld-frame.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tld-frame.html.xsl
@@ -3,7 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
-  - Copyright (c) 2022 Contributors to the Eclipse Foundation
+  - Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tld-summary.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tld-summary.html.xsl
@@ -3,6 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
+  - Copyright (c) 2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 
@@ -42,7 +43,7 @@
 -->
 
 <xsl:stylesheet version="1.0"
-    xmlns:javaee="http://java.sun.com/xml/ns/javaee" 
+    xmlns:jakartaee="https://jakarta.ee/xml/ns/jakartaee" 
     xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
     xmlns:fo="http://www.w3.org/1999/XSL/Format">
     
@@ -52,18 +53,18 @@
 
     <!-- template rule matching source root element -->
     <xsl:template match="/">
-      <xsl:apply-templates select="javaee:tlds/javaee:taglib"/>
+      <xsl:apply-templates select="jakartaee:tlds/jakartaee:taglib"/>
     </xsl:template>
     
-    <xsl:template match="javaee:taglib">
-      <xsl:if test="javaee:short-name=$tlddoc-shortName">
+    <xsl:template match="jakartaee:taglib">
+      <xsl:if test="jakartaee:short-name=$tlddoc-shortName">
         <xsl:variable name="tldname">
           <xsl:choose>
-            <xsl:when test="javaee:display-name!=''">
-              <xsl:value-of select="javaee:display-name"/>
+            <xsl:when test="jakartaee:display-name!=''">
+              <xsl:value-of select="jakartaee:display-name"/>
             </xsl:when>
-            <xsl:when test="javaee:short-name!=''">
-              <xsl:value-of select="javaee:short-name"/>
+            <xsl:when test="jakartaee:short-name!=''">
+              <xsl:value-of select="jakartaee:short-name"/>
             </xsl:when>
             <xsl:otherwise>
               Unnamed TLD
@@ -72,7 +73,7 @@
         </xsl:variable>
         <xsl:variable name="title">
           <xsl:value-of select="$tldname"/>
-          (<xsl:value-of select="/javaee:tlds/javaee:config/javaee:window-title"/>)
+          (<xsl:value-of select="/jakartaee:tlds/jakartaee:config/jakartaee:window-title"/>)
         </xsl:variable>
         <html>
           <head>
@@ -132,16 +133,16 @@
             <hr/>
             <h2><xsl:value-of select="$tldname"/></h2>
             <hr/>
-            <xsl:if test="(javaee:uri!='') and (javaee:short-name!='')">
+            <xsl:if test="(jakartaee:uri!='') and (jakartaee:short-name!='')">
               <b>Standard Syntax:</b><br/>
               <code>
                 &#160;&#160;&#160;&#160;
                 <xsl:choose>
-                  <xsl:when test='starts-with(javaee:uri,"/WEB-INF/tags")'>
-                    &lt;%@ taglib prefix="<xsl:value-of select="javaee:short-name"/>" tagdir="<xsl:value-of select="javaee:uri"/>" %&gt;<br/>
+                  <xsl:when test='starts-with(jakartaee:uri,"/WEB-INF/tags")'>
+                    &lt;%@ taglib prefix="<xsl:value-of select="jakartaee:short-name"/>" tagdir="<xsl:value-of select="jakartaee:uri"/>" %&gt;<br/>
                   </xsl:when>
                   <xsl:otherwise>
-                    &lt;%@ taglib prefix="<xsl:value-of select="javaee:short-name"/>" uri="<xsl:value-of select="javaee:uri"/>" %&gt;<br/>
+                    &lt;%@ taglib prefix="<xsl:value-of select="jakartaee:short-name"/>" uri="<xsl:value-of select="jakartaee:uri"/>" %&gt;<br/>
                   </xsl:otherwise>
                 </xsl:choose>
               </code>
@@ -150,23 +151,23 @@
               <code>
                 &#160;&#160;&#160;&#160;
                 <xsl:choose>
-                  <xsl:when test='starts-with(javaee:uri,"/WEB-INF/tags")'>
-                    &lt;anyxmlelement xmlns:<xsl:value-of select="javaee:short-name"/>="urn:jsptagdir:<xsl:value-of select="javaee:uri"/>" /&gt;<br/>
+                  <xsl:when test='starts-with(jakartaee:uri,"/WEB-INF/tags")'>
+                    &lt;anyxmlelement xmlns:<xsl:value-of select="jakartaee:short-name"/>="urn:jsptagdir:<xsl:value-of select="jakartaee:uri"/>" /&gt;<br/>
                   </xsl:when>
-                  <xsl:when test='starts-with(javaee:uri,"/")'>
-                    &lt;anyxmlelement xmlns:<xsl:value-of select="javaee:short-name"/>="urn:jsptld:<xsl:value-of select="javaee:uri"/>" /&gt;<br/>
+                  <xsl:when test='starts-with(jakartaee:uri,"/")'>
+                    &lt;anyxmlelement xmlns:<xsl:value-of select="jakartaee:short-name"/>="urn:jsptld:<xsl:value-of select="jakartaee:uri"/>" /&gt;<br/>
                   </xsl:when>
                   <xsl:otherwise>
-                    &lt;anyxmlelement xmlns:<xsl:value-of select="javaee:short-name"/>="<xsl:value-of select="javaee:uri"/>" /&gt;<br/>
+                    &lt;anyxmlelement xmlns:<xsl:value-of select="jakartaee:short-name"/>="<xsl:value-of select="jakartaee:uri"/>" /&gt;<br/>
                   </xsl:otherwise>
                 </xsl:choose>
               </code>
               <hr/>
             </xsl:if>
             <xsl:choose>
-              <xsl:when test="javaee:description!=''">
+              <xsl:when test="jakartaee:description!=''">
                 <pre>
-                  <xsl:value-of select="javaee:description" disable-output-escaping="yes"/>
+                  <xsl:value-of select="jakartaee:description" disable-output-escaping="yes"/>
                 </pre>
               </xsl:when>
               <xsl:otherwise>
@@ -183,8 +184,8 @@
               <tr>
                 <td>Display Name</td>
                 <xsl:choose>
-                  <xsl:when test="javaee:display-name!=''">
-                    <td><xsl:value-of select="javaee:display-name"/></td>
+                  <xsl:when test="jakartaee:display-name!=''">
+                    <td><xsl:value-of select="jakartaee:display-name"/></td>
                   </xsl:when>
                   <xsl:otherwise>
                     <td><i>None</i></td>
@@ -194,8 +195,8 @@
               <tr>
                 <td>Version</td>
                 <xsl:choose>
-                  <xsl:when test="javaee:tlib-version!=''">
-                    <td><xsl:value-of select="javaee:tlib-version"/></td>
+                  <xsl:when test="jakartaee:tlib-version!=''">
+                    <td><xsl:value-of select="jakartaee:tlib-version"/></td>
                   </xsl:when>
                   <xsl:otherwise>
                     <td><i>None</i></td>
@@ -205,8 +206,8 @@
               <tr>
                 <td>Short Name</td>
                 <xsl:choose>
-                  <xsl:when test="javaee:short-name!=''">
-                    <td><xsl:value-of select="javaee:short-name"/></td>
+                  <xsl:when test="jakartaee:short-name!=''">
+                    <td><xsl:value-of select="jakartaee:short-name"/></td>
                   </xsl:when>
                   <xsl:otherwise>
                     <td><i>None</i></td>
@@ -216,8 +217,8 @@
               <tr>
                 <td>URI</td>
                 <xsl:choose>
-                  <xsl:when test="javaee:uri!=''">
-                    <td><xsl:value-of select="javaee:uri"/></td>
+                  <xsl:when test="jakartaee:uri!=''">
+                    <td><xsl:value-of select="jakartaee:uri"/></td>
                   </xsl:when>
                   <xsl:otherwise>
                     <td><i>None</i></td>
@@ -228,53 +229,53 @@
             &#160;
             <p/>
             <!-- tags and tag files -->
-            <xsl:if test="(count(javaee:tag)+count(javaee:tag-file)) > 0">
+            <xsl:if test="(count(jakartaee:tag)+count(jakartaee:tag-file)) > 0">
               <table border="1" cellpadding="3" cellspacing="0" width="100%">
                 <tr bgcolor="#CCCCFF" class="TableHeadingColor">
                   <td colspan="2">
                     <font size="+2"><b>Tag Summary</b></font>
                   </td>
                 </tr>
-                <xsl:apply-templates select="javaee:tag|javaee:tag-file"/>
+                <xsl:apply-templates select="jakartaee:tag|jakartaee:tag-file"/>
               </table>
               &#160;
               <p/>
             </xsl:if>
             <!-- functions -->
-            <xsl:if test="count(javaee:function) > 0">
+            <xsl:if test="count(jakartaee:function) > 0">
               <table border="1" cellpadding="3" cellspacing="0" width="100%">
                 <tr bgcolor="#CCCCFF" class="TableHeadingColor">
                   <td colspan="3">
                     <font size="+2"><b>Function Summary</b></font>
                   </td>
                 </tr>
-                <xsl:apply-templates select="javaee:function"/>
+                <xsl:apply-templates select="jakartaee:function"/>
               </table>
               &#160;
               <p/>
             </xsl:if>
             <!-- validators -->
-            <xsl:if test="count(javaee:validator) > 0">
+            <xsl:if test="count(jakartaee:validator) > 0">
               <table border="1" cellpadding="3" cellspacing="0" width="100%">
                 <tr bgcolor="#CCCCFF" class="TableHeadingColor">
                   <td colspan="2">
                     <font size="+2"><b>Tag Library Validator</b></font>
                   </td>
                 </tr>
-                <xsl:apply-templates select="javaee:validator"/>
+                <xsl:apply-templates select="jakartaee:validator"/>
               </table>
               &#160;
               <p/>
             </xsl:if>
             <!-- listeners -->
-            <xsl:if test="count(javaee:listener) > 0">
+            <xsl:if test="count(jakartaee:listener) > 0">
               <table border="1" cellpadding="3" cellspacing="0" width="100%">
                 <tr bgcolor="#CCCCFF" class="TableHeadingColor">
                   <td>
                     <font size="+2"><b>Listeners</b></font>
                   </td>
                 </tr>
-                <xsl:apply-templates select="javaee:listener"/>
+                <xsl:apply-templates select="jakartaee:listener"/>
               </table>
               &#160;
               <p/>
@@ -336,20 +337,20 @@
       </xsl:if>
     </xsl:template>
     
-    <xsl:template match="javaee:tag|javaee:tag-file">
+    <xsl:template match="jakartaee:tag|jakartaee:tag-file">
       <tr bgcolor="white" class="TableRowColor">
         <td width="15%">
           <b>
             <xsl:element name="a">
-              <xsl:attribute name="href"><xsl:value-of select="javaee:name"/>.html</xsl:attribute>
-              <xsl:value-of select="javaee:name"/>
+              <xsl:attribute name="href"><xsl:value-of select="jakartaee:name"/>.html</xsl:attribute>
+              <xsl:value-of select="jakartaee:name"/>
             </xsl:element>
           </b>
         </td>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:description!=''">
-              <xsl:value-of select="javaee:description" disable-output-escaping="yes"/>
+            <xsl:when test="jakartaee:description!=''">
+              <xsl:value-of select="jakartaee:description" disable-output-escaping="yes"/>
             </xsl:when>
             <xsl:otherwise>
               <i>No Description</i>
@@ -359,24 +360,24 @@
       </tr>
     </xsl:template>
 
-    <xsl:template match="javaee:function">
+    <xsl:template match="jakartaee:function">
       <tr bgcolor="white" class="TableRowColor">
         <td width="15%" nowrap="" align="right">
-          <code><xsl:value-of select='substring-before(normalize-space(javaee:function-signature)," ")'/></code>
+          <code><xsl:value-of select='substring-before(normalize-space(jakartaee:function-signature)," ")'/></code>
         </td>
         <td width="15%" nowrap="">
           <code><b>
             <xsl:element name="a">
-              <xsl:attribute name="href"><xsl:value-of select="javaee:name"/>.fn.html</xsl:attribute>
-              <xsl:value-of select="javaee:name"/>
+              <xsl:attribute name="href"><xsl:value-of select="jakartaee:name"/>.fn.html</xsl:attribute>
+              <xsl:value-of select="jakartaee:name"/>
             </xsl:element>
-            </b>( <xsl:value-of select='substring-after(normalize-space(javaee:function-signature),"(")'/>            
+            </b>( <xsl:value-of select='substring-after(normalize-space(jakartaee:function-signature),"(")'/>            
           </code>
         </td>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:description!=''">
-              <xsl:value-of select="javaee:description" disable-output-escaping="yes"/>
+            <xsl:when test="jakartaee:description!=''">
+              <xsl:value-of select="jakartaee:description" disable-output-escaping="yes"/>
             </xsl:when>
             <xsl:otherwise>
               <i>No Description</i>
@@ -386,21 +387,21 @@
       </tr>
     </xsl:template>
         
-    <xsl:template match="javaee:validator">
+    <xsl:template match="jakartaee:validator">
       <tr valign="top" bgcolor="white" class="TableRowColor">
         <td width="15%">
-          <b><xsl:value-of select="javaee:validator-class"/></b>
+          <b><xsl:value-of select="jakartaee:validator-class"/></b>
         </td>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:description!=''">
-              <xsl:value-of select="javaee:description" disable-output-escaping="yes"/>
+            <xsl:when test="jakartaee:description!=''">
+              <xsl:value-of select="jakartaee:description" disable-output-escaping="yes"/>
             </xsl:when>
             <xsl:otherwise>
               <i>No Description</i>
             </xsl:otherwise>
           </xsl:choose>
-          <xsl:if test="count(javaee:init-param)>0">
+          <xsl:if test="count(jakartaee:init-param)>0">
             <blockquote>
               <b>Initialization Parameters:</b><br/>
               <table border="1">
@@ -409,7 +410,7 @@
                   <td><b>Value</b></td>
                   <td><b>Description</b></td>
                 </tr>
-                <xsl:apply-templates select="javaee:init-param"/>
+                <xsl:apply-templates select="jakartaee:init-param"/>
               </table>
             </blockquote>
           </xsl:if>
@@ -417,14 +418,14 @@
       </tr>
     </xsl:template>
     
-    <xsl:template match="javaee:init-param">
+    <xsl:template match="jakartaee:init-param">
       <tr valign="top">
-        <td><xsl:value-of select="javaee:param-name"/></td>
-        <td><xsl:value-of select="javaee:param-value"/></td>
+        <td><xsl:value-of select="jakartaee:param-name"/></td>
+        <td><xsl:value-of select="jakartaee:param-value"/></td>
         <td>
           <xsl:choose>
-            <xsl:when test="javaee:param-description!=''">
-              <xsl:value-of select="javaee:param-description"/>
+            <xsl:when test="jakartaee:param-description!=''">
+              <xsl:value-of select="jakartaee:param-description"/>
             </xsl:when>
             <xsl:otherwise>
               <i>No Description</i>
@@ -434,10 +435,10 @@
       </tr>
     </xsl:template>
     
-    <xsl:template match="javaee:listener">
+    <xsl:template match="jakartaee:listener">
       <tr valign="top" bgcolor="white" class="TableRowColor">
         <td>
-          <b><xsl:value-of select="javaee:listener-class"/></b>
+          <b><xsl:value-of select="jakartaee:listener-class"/></b>
         </td>
       </tr>
     </xsl:template>

--- a/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tld-summary.html.xsl
+++ b/tagsdoc/src/main/resources/com/sun/tlddoc/resources/tld-summary.html.xsl
@@ -3,7 +3,7 @@
 <!--
   - <license>
   - Copyright (c) 2003-2004, Sun Microsystems, Inc.
-  - Copyright (c) 2022 Contributors to the Eclipse Foundation
+  - Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
   - All rights reserved.
   - 
   - Redistribution and use in source and binary forms, with or without 


### PR DESCRIPTION
Fixes #179

- Update TLDs to Jakarta EE Namespace
- Update TLDDoc to generate documentation for the updated TLDs.
- The xsl updates were necessary as the tlddoc output would be empty. There' a lot I don't know, but, I found this to be the minimum to generate the proper documentation.  Please test to ensure everything looks good. 