### PR TITLE
Fix javadoc for tagsdoc

### DIFF
--- a/tagsdoc/pom.xml
+++ b/tagsdoc/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2022 Contributors to the Eclipse Foundation
+    Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -52,7 +52,7 @@
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
                 </configuration>
             </plugin>
-            <!-- JavaDoc Not Neeed for this Module -->
+            <!-- JavaDoc not needed for this module -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
@@ -60,7 +60,7 @@
                     <arguments>-Dmaven.javadoc.skip=true</arguments>
                 </configuration>
             </plugin>
-            <!-- Skip JavaDoc Errors -->
+            <!-- Skip JavaDoc errors -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>

--- a/tagsdoc/pom.xml
+++ b/tagsdoc/pom.xml
@@ -21,16 +21,16 @@
     <groupId>org.glassfish.web</groupId>
     <artifactId>tagsdoc</artifactId>
     <version>1.0-SNAPSHOT</version>
-	<licenses>
-		<license>
-			<name>New BSD License</name>
-			<url>http://opensource.org/licenses/BSD-3-Clause</url>
-		</license>
-	</licenses>
+    <licenses>
+        <license>
+            <name>New BSD License</name>
+            <url>http://opensource.org/licenses/BSD-3-Clause</url>
+        </license>
+    </licenses>
 
     <description>
             Jakarta Tags EE10+ Specific Tag Library Documentation Generator. This was branched off TLDDoc, version 1.3. 
-    </description> 
+    </description>
 
 
     <build>
@@ -50,6 +50,23 @@
                 <configuration>
                     <release>11</release>
                     <compilerArgument>-Xlint:unchecked</compilerArgument>
+                </configuration>
+            </plugin>
+            <!-- JavaDoc Not Neeed for this Module -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <arguments>-Dmaven.javadoc.skip=true</arguments>
+                </configuration>
+            </plugin>
+            <!-- Skip JavaDoc Errors -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.3.2</version>
+                <configuration>
+                    <doclint>all,-missing</doclint>
                 </configuration>
             </plugin>
         </plugins>

--- a/tagsdoc/src/main/java/com/sun/tlddoc/TLDDocGenerator.java
+++ b/tagsdoc/src/main/java/com/sun/tlddoc/TLDDocGenerator.java
@@ -1,6 +1,7 @@
 /*
  * <license>
  * Copyright (c) 2003-2004, Sun Microsystems, Inc.
+ * Copyright (c) 2022-2022 Contributors to the Eclipse Foundation
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without 

--- a/tagsdoc/src/main/java/com/sun/tlddoc/TLDDocGenerator.java
+++ b/tagsdoc/src/main/java/com/sun/tlddoc/TLDDocGenerator.java
@@ -346,7 +346,7 @@ public class TLDDocGenerator {
      * Adds all the tag libraries found in the given web application
      * packaged as a WAR file.
      *
-     * @param war The war containing the web application
+     * @param path The war containing the web application
      */
     public void addWAR( File path ) {
         try {
@@ -370,7 +370,7 @@ public class TLDDocGenerator {
     /**
      * Adds the given directory of tag files.
      *
-     * @param tld The tag directory to add
+     * @param tagdir The tag directory to add
      */
     public void addTagDir( File tagdir ) {
         addTagLibrary( new TagDirImplicitTagLibrary( tagdir ) );

--- a/tagsdoc/src/main/java/com/sun/tlddoc/tagfileparser/ParseException.java
+++ b/tagsdoc/src/main/java/com/sun/tlddoc/tagfileparser/ParseException.java
@@ -22,7 +22,7 @@ public class ParseException extends Exception {
    * This constructor calls its super class with the empty string
    * to force the "toString" method of parent class "Throwable" to
    * print the error message in the form:
-   *     ParseException: <result of getMessage>
+   *     ParseException: result of getMessage
    */
   public ParseException(Token currentTokenVal,
                         int[][] expectedTokenSequencesVal,


### PR DESCRIPTION
workaround for #215
 - Skipping majority of the errors  via doclint
 - Fixing a few necessary errors 
 - Skipped tagdoc javadoc jar since I don't believe we need it published? 