### PR TITLE
Update api javadoc copyright date range to start with 2018

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -2,7 +2,7 @@
 <!--
 
     Copyright (c) 1997, 2020 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2021-2021 Contributors to the Eclipse Foundation
+    Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -291,7 +291,7 @@
                             <header><![CDATA[<br>Jakarta Standard Tag Library API v${project.version}]]></header>
                             <bottom><![CDATA[
 Comments to: <a href="mailto:jstl-dev@eclipse.org">jstl-dev@eclipse.org</a>.<br>
-Copyright &#169; 2019, ${current.year} Eclipse Foundation. All rights reserved.<br>
+Copyright &#169; 2018, ${current.year} Eclipse Foundation. All rights reserved.<br>
 Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
                             </bottom>
                             <docfilessubdirs>true</docfilessubdirs>


### PR DESCRIPTION
fixes #217