### PR TITLE
Resolving failing TCK

### DIFF
--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -112,6 +112,13 @@
             <groupId>xalan</groupId>
             <artifactId>xalan</artifactId>
             <version>2.7.2</version>
+            <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>xml-apis</groupId>
+                    <artifactId>xml-apis</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -24,13 +24,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.6</version>
+        <version>1.0.7</version>
         <relativePath/>
     </parent>
 
     <groupId>org.glassfish.web</groupId>
     <artifactId>jakarta.servlet.jsp.jstl</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>3.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Jakarta Standard Tag Library Implementation</name>
@@ -106,7 +106,8 @@
         <dependency>
             <groupId>jakarta.servlet.jsp.jstl</groupId>
             <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>3.0.0</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>xalan</groupId>
@@ -179,7 +180,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <!-- Restricts the Java version to 11 -->
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -190,13 +191,6 @@
                 </configuration>
             </plugin>
 
-            <!-- Execute unit tests -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M6</version>
-            </plugin>
-            
             <!-- Creates the OSGi MANIFEST.MF file -->
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -230,17 +224,15 @@
                             org.glassfish.jstl.integration
                         </Export-Package>
                         <Import-Package>
-                            !org.apache.xpath,
-                            !org.apache.xpath.objects,
-                            !org.apache.xpath.jaxp,
+                            !org.apache.bcel,
+                            !org.apache.regexp,
                             !org.apache.xml,
                             !org.apache.xml.dtm,
                             !org.apache.xml.utils,
-                            !org.apache.xalan,
-                            !org.apache.xalan.res,
+                            !org.apache.xpath,
+                            !org.apache.xpath.jaxp,
+                            !org.apache.xpath.objects,
                             !org.apache.xpath.res,
-                            !org.apache.regexp,
-                            !org.apache.bcel,
                             !java_cup.runtime,
                             !trax,
                             org.xml.sax.ext,
@@ -258,7 +250,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <!-- Adds the manifest file created by the org.apache.felix:maven-bundle-plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -279,7 +271,7 @@
                     </archive>
                 </configuration>
             </plugin>
-            
+
             <!-- Post process the jar we created by including XALAN and moving packages -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -340,12 +332,9 @@
                     </execution>
                 </executions>
             </plugin>
-       
-            <!-- Creates the source jar -->
+
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.2.1</version>
                 <configuration>
                     <includePom>true</includePom>
                 </configuration>
@@ -353,15 +342,12 @@
                     <execution>
                        <id>attach-sources</id>
                        <goals>
-                           <goal>jar-no-fork</goal> 
+                           <goal>jar-no-fork</goal>
                        </goals>
                     </execution>
                 </executions>
             </plugin>
-            
-            <!-- 
-                Create Javadoc for IMPL jar
-            -->
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
@@ -382,7 +368,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.3.1</version>
                 <configuration>
@@ -421,76 +406,74 @@ Copyright &#169; 2019, ${current.year} Eclipse Foundation. All rights reserved.
             </plugin>
         </plugins>
     </build>
-    
-	<profiles>
-		<!-- 
-		    Generation of TLDDocs typically fails with the following when excuted directly from the impl module:
-		
-		    [WARNING] 
-			Could not transfer metadata org.glassfish.web:tagsdoc:1.0-SNAPSHOT/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/): 
-			
-			transfer failed for http://0.0.0.0/org/glassfish/web/tagsdoc/1.0-SNAPSHOT/maven-metadata.xml
 
-		    [WARNING] 
-			org.glassfish.web:tagsdoc:1.0-SNAPSHOT/maven-metadata.xmlfailed to transfer from http://0.0.0.0/ during a previous attempt. 
-			This failure was cached in the local repository and resolution will not be reattempted until the update interval of 
-			maven-default-http-blocker has elapsed or updates are forced. 
-			
-			
-			Original error: 
-			
-			Could not transfer metadata org.glassfish.web:tagsdoc:1.0-SNAPSHOT/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/): 
-			
-			transfer failed for http://0.0.0.0/org/glassfish/web/tagsdoc/1.0-SNAPSHOT/maven-metadata.xml
-		
-		
-		-->
-		<profile>
-			<id>tlddocs</id>
-			<build>
-				<plugins>
-					<!-- Generate the TLD docs -->
-					<plugin>
-						<groupId>org.codehaus.mojo</groupId>
-						<artifactId>exec-maven-plugin</artifactId>
-						<version>3.0.0</version>
-						<executions>
-							<execution>
-								<id>generateTldDoc</id>
-								<phase>prepare-package</phase>
-								<goals>
-									<goal>java</goal>
-								</goals>
-								<configuration>
-									<includePluginDependencies>true</includePluginDependencies>
-									<includeProjectDependencies>false</includeProjectDependencies>
-									<mainClass>com.sun.tlddoc.TLDDoc</mainClass>
-									<arguments>
-										<argument>-doctitle</argument>
-										<argument>Jakarta Tags doc</argument>
-										<argument>-windowtitle</argument>
-										<argument>Jakarta Tags Doc</argument>
-										<argument>-d</argument>
-										<argument>${project.build.directory}/tlddoc</argument>
-										<argument>${project.basedir}/src/main/resources/META-INF/sql.tld</argument>
-										<argument>${project.basedir}/src/main/resources/META-INF/x.tld</argument>
-										<argument>${project.basedir}/src/main/resources/META-INF/fmt.tld</argument>
-										<argument>${project.basedir}/src/main/resources/META-INF/c.tld</argument>
-										<argument>${project.basedir}/src/main/resources/META-INF/fn.tld</argument>
-									</arguments>
-								</configuration>
-							</execution>
-						</executions>
-						<dependencies>
-							<dependency>
-								<groupId>org.glassfish.web</groupId>
-								<artifactId>tagsdoc</artifactId>
-								<version>1.0-SNAPSHOT</version>
-							</dependency>
-						</dependencies>
-					</plugin>
-				</plugins>
-			</build>
-		</profile>
-	</profiles>
+    <profiles>
+        <!--
+          Generation of TLDDocs typically fails with the following when excuted directly from the impl module:
+
+          [WARNING]
+          Could not transfer metadata org.glassfish.web:tagsdoc:1.0-SNAPSHOT/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/):
+
+          transfer failed for http://0.0.0.0/org/glassfish/web/tagsdoc/1.0-SNAPSHOT/maven-metadata.xml
+
+          [WARNING]
+          org.glassfish.web:tagsdoc:1.0-SNAPSHOT/maven-metadata.xmlfailed to transfer from http://0.0.0.0/ during a previous attempt.
+          This failure was cached in the local repository and resolution will not be reattempted until the update interval of
+          maven-default-http-blocker has elapsed or updates are forced.
+
+
+          Original error:
+
+          Could not transfer metadata org.glassfish.web:tagsdoc:1.0-SNAPSHOT/maven-metadata.xml from/to maven-default-http-blocker (http://0.0.0.0/):
+
+          transfer failed for http://0.0.0.0/org/glassfish/web/tagsdoc/1.0-SNAPSHOT/maven-metadata.xml
+        -->
+        <profile>
+            <id>tlddocs</id>
+            <build>
+                <plugins>
+                    <!-- Generate the TLD docs -->
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>generateTldDoc</id>
+                                <phase>prepare-package</phase>
+                                <goals>
+                                    <goal>java</goal>
+                                </goals>
+                                <configuration>
+                                    <includePluginDependencies>true</includePluginDependencies>
+                                    <includeProjectDependencies>false</includeProjectDependencies>
+                                    <mainClass>com.sun.tlddoc.TLDDoc</mainClass>
+                                    <arguments>
+                                        <argument>-doctitle</argument>
+                                        <argument>Jakarta Tags doc</argument>
+                                        <argument>-windowtitle</argument>
+                                        <argument>Jakarta Tags Doc</argument>
+                                        <argument>-d</argument>
+                                        <argument>${project.build.directory}/tlddoc</argument>
+                                        <argument>${project.basedir}/src/main/resources/META-INF/sql.tld</argument>
+                                        <argument>${project.basedir}/src/main/resources/META-INF/x.tld</argument>
+                                        <argument>${project.basedir}/src/main/resources/META-INF/fmt.tld</argument>
+                                        <argument>${project.basedir}/src/main/resources/META-INF/c.tld</argument>
+                                        <argument>${project.basedir}/src/main/resources/META-INF/fn.tld</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.glassfish.web</groupId>
+                                <artifactId>tagsdoc</artifactId>
+                                <version>1.0-SNAPSHOT</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/DocumentBuilderProvider.java
+++ b/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/DocumentBuilderProvider.java
@@ -16,14 +16,34 @@
 
 package org.apache.taglibs.standard.tag.common.xml;
 
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 
 /**
+ * Provides preconfigured {@link DocumentBuilder} instances.
+ *
  * @author David Matejcek
  */
 public class DocumentBuilderProvider {
+
+    private static final DocumentBuilderFactory DBF;
+    private static final DocumentBuilderFactory DBF_SECURE;
+    static {
+        DBF = DocumentBuilderFactory.newInstance();
+        DBF.setNamespaceAware(true);
+        DBF.setValidating(false);
+
+        DBF_SECURE = DocumentBuilderFactory.newInstance();
+        DBF_SECURE.setNamespaceAware(true);
+        DBF_SECURE.setValidating(false);
+        try {
+            DBF_SECURE.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        } catch (ParserConfigurationException e) {
+            throw new Error("Parser does not support secure processing");
+        }
+    }
 
     /**
      * Creates a namespace-aware {@link DocumentBuilder} with disabled validation.
@@ -33,15 +53,29 @@ public class DocumentBuilderProvider {
      *
      * @return new {@link DocumentBuilder} instance.
      */
-    static DocumentBuilder createDocumentBuilder() {
+    public static DocumentBuilder createDocumentBuilder() {
         try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            dbf.setNamespaceAware(true);
-            dbf.setValidating(false);
-            return dbf.newDocumentBuilder();
+            return DBF.newDocumentBuilder();
         } catch (ParserConfigurationException e) {
-            // this should never happen with a well-behaving JAXP implementation.
-            throw new Error(e);
+            throw new Error("Could not initialize the DocumentBuilder!", e);
+        }
+    }
+
+
+    /**
+     * Creates a namespace-aware {@link DocumentBuilder} with disabled validation and enabled
+     * {@link XMLConstants#FEATURE_SECURE_PROCESSING}.
+     * <p>
+     * Note that {@link DocumentBuilder} instances are not thread-safe and their implementation can
+     * be chosen as described in {@link DocumentBuilderFactory} documentation.
+     *
+     * @return new {@link DocumentBuilder} instance.
+     */
+    public static DocumentBuilder createSecureDocumentBuilder() {
+        try {
+            return DBF_SECURE.newDocumentBuilder();
+        } catch (ParserConfigurationException e) {
+            throw new Error("Could not initialize the DocumentBuilder!", e);
         }
     }
 }

--- a/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/DocumentBuilderProvider.java
+++ b/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/DocumentBuilderProvider.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.apache.taglibs.standard.tag.common.xml;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+/**
+ * @author David Matejcek
+ */
+public class DocumentBuilderProvider {
+
+    /**
+     * Creates a namespace-aware {@link DocumentBuilder} with disabled validation.
+     * <p>
+     * Note that {@link DocumentBuilder} instances are not thread-safe and their implementation can
+     * be chosen as described in {@link DocumentBuilderFactory} documentation.
+     *
+     * @return new {@link DocumentBuilder} instance.
+     */
+    static DocumentBuilder createDocumentBuilder() {
+        try {
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            dbf.setNamespaceAware(true);
+            dbf.setValidating(false);
+            return dbf.newDocumentBuilder();
+        } catch (ParserConfigurationException e) {
+            // this should never happen with a well-behaving JAXP implementation.
+            throw new Error(e);
+        }
+    }
+}

--- a/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/JSTLNodeList.java
+++ b/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/JSTLNodeList.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2022 Eclipse Foundation and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package org.apache.taglibs.standard.tag.common.xml;
+
+import java.util.Vector;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+class JSTLNodeList extends Vector<Object> implements NodeList   {
+
+    private static final long serialVersionUID = -1217630367839271134L;
+
+    Vector<Object> nodeVector;
+
+    JSTLNodeList(Vector<Object> nodeVector) {
+        this.nodeVector = nodeVector;
+    }
+
+
+    JSTLNodeList(NodeList nl) {
+        nodeVector = new Vector<>();
+        // p("[JSTLNodeList] nodelist details");
+        for (int i = 0; i < nl.getLength(); i++) {
+            Node currNode = nl.item(i);
+            // XPathUtil.printDetails ( currNode );
+            nodeVector.add(i, currNode);
+        }
+    }
+
+
+    JSTLNodeList(Node n) {
+        nodeVector = new Vector<>();
+        nodeVector.addElement(n);
+    }
+
+
+    JSTLNodeList(Object o) {
+        nodeVector = new Vector<>();
+
+        if (o instanceof NodeList) {
+            NodeList nl = (NodeList) o;
+            for (int i = 0; i < nl.getLength(); i++) {
+                Node currNode = nl.item(i);
+                // XPathUtil.printDetails ( currNode );
+                nodeVector.add(i, currNode);
+            }
+        } else {
+            nodeVector.addElement(o);
+        }
+    }
+
+
+    @Override
+    public Node item(int index) {
+        return (Node) nodeVector.elementAt(index);
+    }
+
+
+    @Override
+    public Object elementAt(int index) {
+        return nodeVector.elementAt(index);
+    }
+
+
+    @Override
+    public Object get(int index) {
+        return nodeVector.get(index);
+    }
+
+
+    @Override
+    public int getLength() {
+        return nodeVector.size();
+    }
+
+
+    @Override
+    public int size() {
+        return nodeVector.size();
+    }
+
+    // Can implement other Vector methods to redirect those methods to
+    // the vector in the variable param. As we are not using them as part
+    // of this implementation we are not doing that here. If this changes
+    // then we need to override those methods accordingly
+}

--- a/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/JSTLXPathFactory.java
+++ b/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/JSTLXPathFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -17,18 +18,21 @@
 
 package org.apache.taglibs.standard.tag.common.xml;
 
+import javax.xml.xpath.XPath;
+
 import org.apache.xpath.jaxp.XPathFactoryImpl;
 
 /**
  * This factory class is added to provide access to our own implementation
  * of XPath, so that we can support a generic Object type in return type
- * arguement for XPath's evaluate instance method. 
- * 
+ * arguement for XPath's evaluate instance method.
+ *
  * @author dhirup
  */
 public class JSTLXPathFactory extends XPathFactoryImpl {
-    
-    public javax.xml.xpath.XPath newXPath() {
-        return new org.apache.taglibs.standard.tag.common.xml.JSTLXPathImpl(null, null);
-    }    
+
+    @Override
+    public XPath newXPath() {
+        return new JSTLXPathImpl(null, null);
+    }
 }

--- a/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/JSTLXPathImpl.java
+++ b/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/JSTLXPathImpl.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 1997-2018 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -17,541 +18,298 @@
 
 package org.apache.taglibs.standard.tag.common.xml;
 
+import java.io.IOException;
 
-import javax.xml.namespace.QName;
 import javax.xml.namespace.NamespaceContext;
-import javax.xml.xpath.XPathExpressionException;
+import javax.xml.namespace.QName;
+import javax.xml.transform.TransformerException;
 import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFunctionException;
 import javax.xml.xpath.XPathFunctionResolver;
 import javax.xml.xpath.XPathVariableResolver;
-import javax.xml.xpath.XPathExpression;
 
 import org.apache.xml.dtm.DTM;
-import org.apache.xpath.*;
+import org.apache.xpath.XPath;
+import org.apache.xpath.XPathContext;
+import org.apache.xpath.jaxp.JAXPExtensionsProvider;
+import org.apache.xpath.jaxp.JAXPPrefixResolver;
+import org.apache.xpath.jaxp.JAXPVariableStack;
+import org.apache.xpath.objects.XNodeSet;
 import org.apache.xpath.objects.XObject;
 import org.apache.xpath.res.XPATHErrorResources;
-import org.apache.xalan.res.XSLMessages;
-
-import org.w3c.dom.Node;
-import org.w3c.dom.DOMImplementation;
+import org.apache.xpath.res.XPATHMessages;
 import org.w3c.dom.Document;
+import org.w3c.dom.Node;
 import org.w3c.dom.traversal.NodeIterator;
-
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
-
-import javax.xml.parsers.*;
-
-import java.io.IOException;
 
 /**
  * The JSTLXPathImpl class provides implementation for the methods defined  in
  * javax.xml.xpath.XPath interface. This provide simple access to the results
- * of an XPath expression. 
- * 
- * This class provides our own implementation of XPath, so that we can support 
- * a generic Object type in returnType arguement for XPath's evaluate instance 
+ * of an XPath expression.
+ *
+ * This class provides our own implementation of XPath, so that we can support
+ * a generic Object type in returnType arguement for XPath's evaluate instance
  * method.
  *
- * Most of the implementation is exactly similar to what is already provided in 
+ * Most of the implementation is exactly similar to what is already provided in
  * com.sun.org.apache.xpath.internal.jaxp.XPathImpl.java
  */
-public class JSTLXPathImpl implements javax.xml.xpath.XPath {
+class JSTLXPathImpl implements javax.xml.xpath.XPath {
 
-    // Private variables
+    private final XPathVariableResolver origVariableResolver;
+    private final XPathFunctionResolver origFunctionResolver;
+
     private XPathVariableResolver variableResolver;
     private XPathFunctionResolver functionResolver;
-    private XPathVariableResolver origVariableResolver;
-    private XPathFunctionResolver origFunctionResolver;
-    private NamespaceContext namespaceContext=null;
-    private org.apache.xpath.jaxp.JAXPPrefixResolver prefixResolver;
-    // By default Extension Functions are allowed in XPath Expressions. If 
+    private NamespaceContext namespaceContext;
+    private JAXPPrefixResolver prefixResolver;
+
+    // By default Extension Functions are allowed in XPath Expressions. If
     // Secure Processing Feature is set on XPathFactory then the invocation of
     // extensions function need to throw XPathFunctionException
-    private boolean featureSecureProcessing = false; 
+    private boolean featureSecureProcessing;
 
-    JSTLXPathImpl( XPathVariableResolver vr, XPathFunctionResolver fr ) {
+    JSTLXPathImpl(XPathVariableResolver vr, XPathFunctionResolver fr) {
         this.origVariableResolver = this.variableResolver = vr;
         this.origFunctionResolver = this.functionResolver = fr;
     }
 
-    JSTLXPathImpl( XPathVariableResolver vr, XPathFunctionResolver fr, 
-            boolean featureSecureProcessing ) {
+
+    JSTLXPathImpl(XPathVariableResolver vr, XPathFunctionResolver fr, boolean featureSecureProcessing) {
         this.origVariableResolver = this.variableResolver = vr;
         this.origFunctionResolver = this.functionResolver = fr;
         this.featureSecureProcessing = featureSecureProcessing;
     }
 
-    /**
-     * <p>Establishes a variable resolver.</p>
-     *
-     * @param resolver Variable Resolver
-     */
-    public void setXPathVariableResolver(XPathVariableResolver resolver) {
-        if ( resolver == null ) {
-            String fmsg = XSLMessages.createXPATHMessage( 
-                    XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
-                    new Object[] {"XPathVariableResolver"} );
-            throw new NullPointerException( fmsg );
-        }
-        this.variableResolver = resolver;
-    }
 
-    /**
-     * <p>Returns the current variable resolver.</p>
-     *
-     * @return Current variable resolver
-     */
-    public XPathVariableResolver getXPathVariableResolver() {
-        return variableResolver;
-    }
-
-    /**
-     * <p>Establishes a function resolver.</p>
-     *
-     * @param resolver XPath function resolver
-     */
-    public void setXPathFunctionResolver(XPathFunctionResolver resolver) {
-        if ( resolver == null ) {
-            String fmsg = XSLMessages.createXPATHMessage( 
-                    XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
-                    new Object[] {"XPathFunctionResolver"} );
-            throw new NullPointerException( fmsg );
-        }
-        this.functionResolver = resolver;
-    }
-
-    /**
-     * <p>Returns the current function resolver.</p>
-     *
-     * @return Current function resolver
-     */
-    public XPathFunctionResolver getXPathFunctionResolver() {
-        return functionResolver;
-    }
-
-    /**
-     * <p>Establishes a namespace context.</p>
-     *
-     * @param nsContext Namespace context to use
-     */
-    public void setNamespaceContext(NamespaceContext nsContext) {
-        if ( nsContext == null ) {
-            String fmsg = XSLMessages.createXPATHMessage( 
-                    XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
-                    new Object[] {"NamespaceContext"} );
-            throw new NullPointerException( fmsg ); 
-        }
-        this.namespaceContext = nsContext;
-        this.prefixResolver = new org.apache.xpath.jaxp.JAXPPrefixResolver ( nsContext );
-    }
-
-    /**
-     * <p>Returns the current namespace context.</p>
-     *
-     * @return Current Namespace context
-     */
-    public NamespaceContext getNamespaceContext() {
-        return namespaceContext;
-    }
-
-    private static Document d = null;
-    
-    private static DocumentBuilder getParser() {
-        try {
-            // we'd really like to cache those DocumentBuilders, but we can't because:
-            // 1. thread safety. parsers are not thread-safe, so at least
-            //    we need one instance per a thread.
-            // 2. parsers are non-reentrant, so now we are looking at having a
-            // pool of parsers.
-            // 3. then the class loading issue. The look-up procedure of
-            //    DocumentBuilderFactory.newInstance() depends on context class loader
-            //    and system properties, which may change during the execution of JVM.
-            //
-            // so we really have to create a fresh DocumentBuilder every time we need one
-            // - KK
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            dbf.setNamespaceAware( true );
-            dbf.setValidating( false );
-            return dbf.newDocumentBuilder();
-        } catch (ParserConfigurationException e) {
-            // this should never happen with a well-behaving JAXP implementation. 
-            throw new Error(e);
-        }
-    }
-
-    private static Document getDummyDocument( ) {
-        // we don't need synchronization here; even if two threads
-        // enter this code at the same time, we just waste a little time
-        if(d==null) {
-            DOMImplementation dim = getParser().getDOMImplementation();
-            d = dim.createDocument("http://java.sun.com/jaxp/xpath",
-                "dummyroot", null);
-        }
-        return d;
-    }
-
-    
-    private XObject eval(String expression, Object contextItem)
-        throws javax.xml.transform.TransformerException {
-        org.apache.xpath.XPath xpath = new org.apache.xpath.XPath( expression,
-            null, prefixResolver, org.apache.xpath.XPath.SELECT );
-        org.apache.xpath.XPathContext xpathSupport = null;
-        if ( functionResolver != null ) {
-            org.apache.xpath.jaxp.JAXPExtensionsProvider jep = 
-                    new org.apache.xpath.jaxp.JAXPExtensionsProvider(
-                    functionResolver, featureSecureProcessing );
-            xpathSupport = new org.apache.xpath.XPathContext( jep );
-        } else { 
-            xpathSupport = new org.apache.xpath.XPathContext();
-        }
-
-        XObject xobj = null;
-        
-        xpathSupport.setVarStack(new org.apache.xpath.jaxp.JAXPVariableStack(variableResolver));
-        
-        // If item is null, then we will create a a Dummy contextNode
-        if ( contextItem instanceof Node ) {
-            xobj = xpath.execute (xpathSupport, (Node)contextItem,
-                    prefixResolver );
-        } else {
-            xobj = xpath.execute ( xpathSupport, DTM.NULL, prefixResolver );
-        }
- 
-        return xobj;
-    }
-        
-    /**
-     * <p>Evaluate an <code>XPath</code> expression in the specified context and return the result as the specified type.</p>
-     *
-     * <p>See "Evaluation of XPath Expressions" section of JAXP 1.3 spec
-     * for context item evaluation,
-     * variable, function and <code>QName</code> resolution and return type conversion.</p>
-     *
-     * <p>If <code>returnType</code> is not one of the types defined in {@link XPathConstants} (
-     * {@link XPathConstants#NUMBER NUMBER},
-     * {@link XPathConstants#STRING STRING},
-     * {@link XPathConstants#BOOLEAN BOOLEAN},
-     * {@link XPathConstants#NODE NODE} or
-     * {@link XPathConstants#NODESET NODESET})
-     * then an <code>IllegalArgumentException</code> is thrown.</p>
-     *
-     * <p>If a <code>null</code> value is provided for
-     * <code>item</code>, an empty document will be used for the
-     * context.
-     * If <code>expression</code> or <code>returnType</code> is <code>null</code>, then a
-     * <code>NullPointerException</code> is thrown.</p>
-     *
-     * @param expression The XPath expression.
-     * @param item The starting context (node or node list, for example).
-     * @param returnType The desired return type.
-     *
-     * @return Result of evaluating an XPath expression as an <code>Object</code> of <code>returnType</code>.
-     *
-     * @throws XPathExpressionException If <code>expression</code> cannot be evaluated.
-     * @throws IllegalArgumentException If <code>returnType</code> is not one of the types defined in {@link XPathConstants}.
-     * @throws NullPointerException If <code>expression</code> or <code>returnType</code> is <code>null</code>.
-     */
-    public Object evaluate(String expression, Object item, QName returnType)
-            throws XPathExpressionException {
-        if ( expression == null ) {
-            String fmsg = XSLMessages.createXPATHMessage( 
-                    XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
-                    new Object[] {"XPath expression"} );
-            throw new NullPointerException ( fmsg );
-        }
-        if ( returnType == null ) {
-            String fmsg = XSLMessages.createXPATHMessage( 
-                    XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
-                    new Object[] {"returnType"} );
-            throw new NullPointerException ( fmsg );
-        }
-        // Checking if requested returnType is supported. returnType need to
-        // be defined in XPathConstants or JSTLXPathConstants
-        if ( !isSupported ( returnType ) ) {
-            String fmsg = XSLMessages.createXPATHMessage(
-                    XPATHErrorResources.ER_UNSUPPORTED_RETURN_TYPE,
-                    new Object[] { returnType.toString() } );
-            throw new IllegalArgumentException ( fmsg );
-        }
-
-        try {
- 
-            XObject resultObject = eval( expression, item );
-            return getResultAsType( resultObject, returnType );
-        } catch ( java.lang.NullPointerException npe ) {
-            // If VariableResolver returns null Or if we get 
-            // NullPointerException at this stage for some other reason
-            // then we have to reurn XPathException 
-            throw new XPathExpressionException ( npe );
-        } catch ( javax.xml.transform.TransformerException te ) {
-            Throwable nestedException = te.getException();
-            if ( nestedException instanceof javax.xml.xpath.XPathFunctionException ) {
-                throw (javax.xml.xpath.XPathFunctionException)nestedException;
-            } else {
-                // For any other exceptions we need to throw 
-                // XPathExpressionException ( as per spec )
-                throw new XPathExpressionException ( te );
-            }
-        } 
-        
-    }
-
-    private boolean isSupported( QName returnType ) {
-        if ( ( returnType.equals( XPathConstants.STRING ) ) ||
-             ( returnType.equals( XPathConstants.NUMBER ) ) ||
-             ( returnType.equals( XPathConstants.BOOLEAN ) ) ||
-             ( returnType.equals( XPathConstants.NODE ) ) ||
-             ( returnType.equals( XPathConstants.NODESET ) ) ||
-             ( returnType.equals( JSTLXPathConstants.OBJECT ) )   ) {
-  
-            return true;
-        }
-        return false;
-     }
-
-    private Object getResultAsType( XObject resultObject, QName returnType )
-        throws javax.xml.transform.TransformerException {
-        // XPathConstants.STRING
-        if ( returnType.equals( XPathConstants.STRING ) ) { 
-            return resultObject.str();
-        }
-        // XPathConstants.NUMBER
-        if ( returnType.equals( XPathConstants.NUMBER ) ) { 
-            return new Double ( resultObject.num());
-        }
-        // XPathConstants.BOOLEAN
-        if ( returnType.equals( XPathConstants.BOOLEAN ) ) { 
-            return Boolean.valueOf( resultObject.bool());
-        }
-        // XPathConstants.NODESET ---ORdered, UNOrdered???
-        if ( returnType.equals( XPathConstants.NODESET ) ) { 
-            return resultObject.nodelist();
-        }
-        // XPathConstants.NODE
-        if ( returnType.equals( XPathConstants.NODE ) ) { 
-            NodeIterator ni = resultObject.nodeset(); 
-            //Return the first node, or null
-            return ni.nextNode();
-        }
-        // JSTLXPathConstants.OBJECT
-        if ( returnType.equals( JSTLXPathConstants.OBJECT ) ) {
-            if (resultObject instanceof org.apache.xpath.objects.XNodeSet)
-                return resultObject.nodelist();
-            else 
-                return resultObject.object();
-        }
-        String fmsg = XSLMessages.createXPATHMessage(
-                XPATHErrorResources.ER_UNSUPPORTED_RETURN_TYPE,
-                new Object[] { returnType.toString()});
-        throw new IllegalArgumentException( fmsg );
-    }
-         
-            
-        
-    /**
-     * <p>Evaluate an XPath expression in the specified context and return the result as a <code>String</code>.</p>
-     *
-     * <p>This method calls {@link #evaluate(String expression, Object item, QName returnType)} with a <code>returnType</code> of
-     * {@link XPathConstants#STRING}.</p>
-     *
-     * <p>See "Evaluation of XPath Expressions" of JAXP 1.3 spec 
-     * for context item evaluation,
-     * variable, function and QName resolution and return type conversion.</p>
-     *
-     * <p>If a <code>null</code> value is provided for
-     * <code>item</code>, an empty document will be used for the
-     * context.
-     * If <code>expression</code> is <code>null</code>, then a <code>NullPointerException</code> is thrown.</p>
-     *
-     * @param expression The XPath expression.
-     * @param item The starting context (node or node list, for example).
-     *
-     * @return The <code>String</code> that is the result of evaluating the expression and
-     *   converting the result to a <code>String</code>.
-     *
-     * @throws XPathExpressionException If <code>expression</code> cannot be evaluated.
-     * @throws NullPointerException If <code>expression</code> is <code>null</code>.
-     */
-    public String evaluate(String expression, Object item)
-        throws XPathExpressionException {
-        return (String)this.evaluate( expression, item, XPathConstants.STRING );
-    }
-
-    /**
-     * <p>Compile an XPath expression for later evaluation.</p>
-     *
-     * <p>If <code>expression</code> contains any {@link javax.xml.xpath.XPathFunction}s,
-     * they must be available via the {@link XPathFunctionResolver}.
-     * An {@link XPathExpressionException} will be thrown if the <code>XPathFunction</code>
-     * cannot be resovled with the <code>XPathFunctionResolver</code>.</p>
-     * 
-     * <p>If <code>expression</code> is <code>null</code>, a <code>NullPointerException</code> is thrown.</p>
-     *
-     * @param expression The XPath expression.
-     *
-     * @return Compiled XPath expression.
-
-     * @throws XPathExpressionException If <code>expression</code> cannot be compiled.
-     * @throws NullPointerException If <code>expression</code> is <code>null</code>.
-     */
-    public XPathExpression compile(String expression)
-        throws XPathExpressionException {
-        // This is never used in JSTL
-        if ( expression == null ) {
-            String fmsg = XSLMessages.createXPATHMessage( 
-                    XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
-                    new Object[] {"XPath expression"} );
-            throw new NullPointerException ( fmsg );
-        }
-        return null;
-        /*
-        try {
-            com.sun.org.apache.xpath.internal.XPath xpath = new XPath (expression, null,
-                    prefixResolver, com.sun.org.apache.xpath.internal.XPath.SELECT );
-            // Can have errorListener
-            com.sun.org.apache.xpath.internal.jaxp.XPathExpressionImpl ximpl = 
-                    new com.sun.org.apache.xpath.internal.jaxp.XPathExpressionImpl (xpath,
-                    prefixResolver, functionResolver, variableResolver,
-                    featureSecureProcessing );
-            return ximpl;
-        } catch ( javax.xml.transform.TransformerException te ) {
-            throw new XPathExpressionException ( te ) ;
-        }
-         **/
-    }
-
-
-    /**
-     * <p>Evaluate an XPath expression in the context of the specified <code>InputSource</code>
-     * and return the result as the specified type.</p>
-     *
-     * <p>This method builds a data model for the {@link InputSource} and calls
-     * {@link #evaluate(String expression, Object item, QName returnType)} on the resulting document object.</p>
-     *
-     * <p>See "Evaluation of XPath Expressions" section of JAXP 1.3 spec 
-     * for context item evaluation,
-     * variable, function and QName resolution and return type conversion.</p>
-     *
-     * <p>If <code>returnType</code> is not one of the types defined in {@link XPathConstants},
-     * then an <code>IllegalArgumentException</code> is thrown.</p>
-     *
-     * <p>If <code>expression</code>, <code>source</code> or <code>returnType</code> is <code>null</code>,
-     * then a <code>NullPointerException</code> is thrown.</p>
-     *
-     * @param expression The XPath expression.
-     * @param source The input source of the document to evaluate over.
-     * @param returnType The desired return type.
-     *
-     * @return The <code>Object</code> that encapsulates the result of evaluating the expression.
-     *
-     * @throws XPathExpressionException If expression cannot be evaluated.
-     * @throws IllegalArgumentException If <code>returnType</code> is not one of the types defined in {@link XPathConstants}.
-     * @throws NullPointerException If <code>expression</code>, <code>source</code> or <code>returnType</code>
-     *   is <code>null</code>.
-     */
-    public Object evaluate(String expression, InputSource source, 
-            QName returnType) throws XPathExpressionException {
-        // Checking validity of different parameters
-        if( source== null ) {
-            String fmsg = XSLMessages.createXPATHMessage( 
-                    XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
-                    new Object[] {"source"} );
-            throw new NullPointerException ( fmsg );
-        }
-        if ( expression == null ) {
-            String fmsg = XSLMessages.createXPATHMessage( 
-                    XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
-                    new Object[] {"XPath expression"} );
-            throw new NullPointerException ( fmsg );
-        }
-        if ( returnType == null ) {
-            String fmsg = XSLMessages.createXPATHMessage( 
-                    XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
-                    new Object[] {"returnType"} );
-            throw new NullPointerException ( fmsg );
-        }
-
-        //Checking if requested returnType is supported. 
-        //returnType need to be defined in XPathConstants
-        if ( !isSupported ( returnType ) ) {
-            String fmsg = XSLMessages.createXPATHMessage(
-                    XPATHErrorResources.ER_UNSUPPORTED_RETURN_TYPE,
-                    new Object[] { returnType.toString() } );
-            throw new IllegalArgumentException ( fmsg );
-        }
-        
-        try {
-
-            Document document = getParser().parse( source );
-
-            XObject resultObject = eval( expression, document );
-            return getResultAsType( resultObject, returnType );
-        } catch ( SAXException e ) {
-            throw new XPathExpressionException ( e );
-        } catch( IOException e ) {
-            throw new XPathExpressionException ( e );            
-        } catch ( javax.xml.transform.TransformerException te ) {
-            Throwable nestedException = te.getException();
-            if ( nestedException instanceof javax.xml.xpath.XPathFunctionException ) {
-                throw (javax.xml.xpath.XPathFunctionException)nestedException;
-            } else {
-                throw new XPathExpressionException ( te );
-            }
-        }
-
-    } 
- 
-
-
-
-    /**
-     * <p>Evaluate an XPath expression in the context of the specified <code>InputSource</code>
-     * and return the result as a <code>String</code>.</p>
-     *
-     * <p>This method calls {@link #evaluate(String expression, InputSource source, QName returnType)} with a
-     * <code>returnType</code> of {@link XPathConstants#STRING}.</p>
-     *
-     * <p>See "Evaluation of XPath Expressions" section of JAXP 1.3 spec
-     * for context item evaluation,
-     * variable, function and QName resolution and return type conversion.</p>
-     *
-     * <p>If <code>expression</code> or <code>source</code> is <code>null</code>,
-     * then a <code>NullPointerException</code> is thrown.</p>
-     *
-     * @param expression The XPath expression.
-     * @param source The <code>InputSource</code> of the document to evaluate over.
-     *
-     * @return The <code>String</code> that is the result of evaluating the expression and
-     *   converting the result to a <code>String</code>.
-     *
-     * @throws XPathExpressionException If expression cannot be evaluated.
-     * @throws NullPointerException If <code>expression</code> or <code>source</code> is <code>null</code>.
-     */
-    public String evaluate(String expression, InputSource source)
-        throws XPathExpressionException {
-        return (String)this.evaluate( expression, source, XPathConstants.STRING );
-    }
-
-    /**
-     * <p>Reset this <code>XPath</code> to its original configuration.</p>
-     *
-     * <p><code>XPath</code> is reset to the same state as when it was created with
-     * {@link javax.xml.xpath.XPathFactory#newXPath()}.
-     * <code>reset()</code> is designed to allow the reuse of existing <code>XPath</code>s
-     * thus saving resources associated with the creation of new <code>XPath</code>s.</p>
-     *
-     * <p>The reset <code>XPath</code> is not guaranteed to have the same
-     * {@link XPathFunctionResolver}, {@link XPathVariableResolver}
-     * or {@link NamespaceContext} <code>Object</code>s, e.g. {@link Object#equals(Object obj)}.
-     * It is guaranteed to have a functionally equal <code>XPathFunctionResolver</code>,
-     * <code>XPathVariableResolver</code>
-     * and <code>NamespaceContext</code>.</p>
-     */
+    @Override
     public void reset() {
         this.variableResolver = this.origVariableResolver;
         this.functionResolver = this.origFunctionResolver;
         this.namespaceContext = null;
     }
- 
+
+
+    @Override
+    public void setXPathVariableResolver(XPathVariableResolver resolver) {
+        if (resolver == null) {
+            String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
+                new Object[] {"XPathVariableResolver"});
+            throw new NullPointerException(fmsg);
+        }
+        this.variableResolver = resolver;
+    }
+
+
+    @Override
+    public XPathVariableResolver getXPathVariableResolver() {
+        return variableResolver;
+    }
+
+
+    @Override
+    public void setXPathFunctionResolver(XPathFunctionResolver resolver) {
+        if (resolver == null) {
+            String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
+                new Object[] {"XPathFunctionResolver"});
+            throw new NullPointerException(fmsg);
+        }
+        this.functionResolver = resolver;
+    }
+
+
+    @Override
+    public XPathFunctionResolver getXPathFunctionResolver() {
+        return functionResolver;
+    }
+
+
+    @Override
+    public void setNamespaceContext(NamespaceContext nsContext) {
+        if (nsContext == null) {
+            String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
+                new Object[] {"NamespaceContext"});
+            throw new NullPointerException(fmsg);
+        }
+        this.namespaceContext = nsContext;
+        this.prefixResolver = new JAXPPrefixResolver(nsContext);
+    }
+
+
+    @Override
+    public NamespaceContext getNamespaceContext() {
+        return namespaceContext;
+    }
+
+
+    @Override
+    public XPathExpression compile(String expression)
+        throws XPathExpressionException {
+        // This is never used in JSTL
+        if (expression == null) {
+            String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
+                new Object[] {"XPath expression"});
+            throw new NullPointerException(fmsg);
+        }
+        return null;
+    }
+
+
+    @Override
+    public Object evaluate(String expression, Object item, QName returnType) throws XPathExpressionException {
+        if (expression == null) {
+            String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
+                new Object[] {"XPath expression"});
+            throw new NullPointerException(fmsg);
+        }
+        if (returnType == null) {
+            String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
+                new Object[] {"returnType"});
+            throw new NullPointerException(fmsg);
+        }
+        // Checking if requested returnType is supported. returnType need to
+        // be defined in XPathConstants or JSTLXPathConstants
+        if (!isSupported(returnType)) {
+            String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_UNSUPPORTED_RETURN_TYPE,
+                new Object[] {returnType.toString()});
+            throw new IllegalArgumentException(fmsg);
+        }
+
+        try {
+            XObject resultObject = eval(expression, item);
+            return getResultAsType(resultObject, returnType);
+        } catch (NullPointerException npe) {
+            // If VariableResolver returns null Or if we get
+            // NullPointerException at this stage for some other reason
+            // then we have to reurn XPathException
+            throw new XPathExpressionException(npe);
+        } catch (TransformerException te) {
+            Throwable nestedException = te.getException();
+            if (nestedException instanceof XPathFunctionException) {
+                throw (XPathFunctionException) nestedException;
+            }
+            // For any other exceptions we need to throw
+            // XPathExpressionException ( as per spec )
+            throw new XPathExpressionException(te);
+        }
+    }
+
+
+    @Override
+    public String evaluate(String expression, Object item) throws XPathExpressionException {
+        return (String) this.evaluate(expression, item, XPathConstants.STRING);
+    }
+
+
+    @Override
+    public Object evaluate(String expression, InputSource source, QName returnType) throws XPathExpressionException {
+        // Checking validity of different parameters
+        if (source == null) {
+            String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
+                new Object[] {"source"});
+            throw new NullPointerException(fmsg);
+        }
+        if (expression == null) {
+            String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
+                new Object[] {"XPath expression"});
+            throw new NullPointerException(fmsg);
+        }
+        if (returnType == null) {
+            String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_ARG_CANNOT_BE_NULL,
+                new Object[] {"returnType"});
+            throw new NullPointerException(fmsg);
+        }
+
+        // Checking if requested returnType is supported.
+        // returnType need to be defined in XPathConstants
+        if (!isSupported(returnType)) {
+            String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_UNSUPPORTED_RETURN_TYPE,
+                new Object[] {returnType.toString()});
+            throw new IllegalArgumentException(fmsg);
+        }
+
+        try {
+            Document document = DocumentBuilderProvider.createDocumentBuilder().parse(source);
+            XObject resultObject = eval(expression, document);
+            return getResultAsType(resultObject, returnType);
+        } catch (SAXException e) {
+            throw new XPathExpressionException(e);
+        } catch (IOException e) {
+            throw new XPathExpressionException(e);
+        } catch (TransformerException te) {
+            Throwable nestedException = te.getException();
+            if (nestedException instanceof XPathFunctionException) {
+                throw (XPathFunctionException) nestedException;
+            }
+            throw new XPathExpressionException(te);
+        }
+    }
+
+
+    @Override
+    public String evaluate(String expression, InputSource source) throws XPathExpressionException {
+        return (String) this.evaluate(expression, source, XPathConstants.STRING);
+    }
+
+
+    private XObject eval(String expression, Object contextItem) throws TransformerException {
+        XPath xpath = new XPath(expression, null, prefixResolver, XPath.SELECT);
+        final XPathContext xpathSupport;
+        if (functionResolver != null) {
+            JAXPExtensionsProvider jep = new JAXPExtensionsProvider(functionResolver, featureSecureProcessing);
+            xpathSupport = new XPathContext(jep);
+        } else {
+            xpathSupport = new XPathContext();
+        }
+
+        xpathSupport.setVarStack(new JAXPVariableStack(variableResolver));
+
+        // If item is null, then we will create a a Dummy contextNode
+        if (contextItem instanceof Node) {
+            return xpath.execute(xpathSupport, (Node) contextItem, prefixResolver);
+        }
+        return xpath.execute(xpathSupport, DTM.NULL, prefixResolver);
+    }
+
+
+    private boolean isSupported(QName returnType) {
+        return returnType.equals(XPathConstants.STRING) || returnType.equals(XPathConstants.NUMBER)
+            || returnType.equals(XPathConstants.BOOLEAN) || returnType.equals(XPathConstants.NODE)
+            || returnType.equals(XPathConstants.NODESET) || returnType.equals(JSTLXPathConstants.OBJECT);
+    }
+
+
+    private Object getResultAsType(XObject resultObject, QName returnType) throws TransformerException {
+        if (returnType.equals(XPathConstants.STRING)) {
+            return resultObject.str();
+        }
+        if (returnType.equals(XPathConstants.NUMBER)) {
+            return Double.valueOf(resultObject.num());
+        }
+        if (returnType.equals(XPathConstants.BOOLEAN)) {
+            return Boolean.valueOf(resultObject.bool());
+        }
+        // XPathConstants.NODESET ---ORdered, UNOrdered???
+        if (returnType.equals(XPathConstants.NODESET)) {
+            return resultObject.nodelist();
+        }
+        if (returnType.equals(XPathConstants.NODE)) {
+            NodeIterator ni = resultObject.nodeset();
+            // Return the first node, or null
+            return ni.nextNode();
+        }
+        if (returnType.equals(JSTLXPathConstants.OBJECT)) {
+            if (resultObject instanceof XNodeSet) {
+                return resultObject.nodelist();
+            }
+            return resultObject.object();
+        }
+        String fmsg = XPATHMessages.createXPATHMessage(XPATHErrorResources.ER_UNSUPPORTED_RETURN_TYPE,
+            new Object[] {returnType.toString()});
+        throw new IllegalArgumentException(fmsg);
+    }
 }

--- a/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/ParseSupport.java
+++ b/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/ParseSupport.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 1997-2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -17,21 +18,20 @@
 
 package org.apache.taglibs.standard.tag.common.xml;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.jsp.JspException;
+import jakarta.servlet.jsp.JspTagException;
+import jakarta.servlet.jsp.PageContext;
+import jakarta.servlet.jsp.tagext.BodyTagSupport;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.jsp.JspException;
-import jakarta.servlet.jsp.JspTagException;
-import jakarta.servlet.jsp.PageContext;
-import jakarta.servlet.jsp.tagext.BodyTagSupport;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMResult;
@@ -72,7 +72,6 @@ public abstract class ParseSupport extends BodyTagSupport {
     private int scopeDom;			   // processed 'scopeDom' attr
 
     // state in support of XML parsing...
-    private DocumentBuilderFactory dbf;
     private DocumentBuilder db;
     private TransformerFactory tf;
     private TransformerHandler th;
@@ -91,7 +90,6 @@ public abstract class ParseSupport extends BodyTagSupport {
 	xml = null;
 	systemId = null;
 	filter = null;
-	dbf = null;
 	db = null;
 	tf = null;
 	th = null;
@@ -107,18 +105,7 @@ public abstract class ParseSupport extends BodyTagSupport {
     public int doEndTag() throws JspException {
       try {
 	
-	// set up our DocumentBuilder
-        if (dbf == null) {
-            dbf = DocumentBuilderFactory.newInstance();
-            dbf.setNamespaceAware(true);
-            dbf.setValidating(false);
-            try {
-                dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            } catch (ParserConfigurationException e) {
-                throw new AssertionError("Parser does not support secure processing");
-            }
-        }
-        db = dbf.newDocumentBuilder();
+    db = DocumentBuilderProvider.createSecureDocumentBuilder();
 
 	// if we've gotten a filter, set up a transformer to support it
 	if (filter != null) {
@@ -166,8 +153,6 @@ public abstract class ParseSupport extends BodyTagSupport {
       } catch (SAXException ex) {
 	throw new JspException(ex);
       } catch (IOException ex) {
-	throw new JspException(ex);
-      } catch (ParserConfigurationException ex) {
 	throw new JspException(ex);
       } catch (TransformerConfigurationException ex) {
 	throw new JspException(ex);

--- a/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/TransformSupport.java
+++ b/impl/src/main/java/org/apache/taglibs/standard/tag/common/xml/TransformSupport.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2022 Contributors to the Eclipse Foundation
  * Copyright (c) 1997-2020 Oracle and/or its affiliates. All rights reserved.
  * Copyright 2004 The Apache Software Foundation
  *
@@ -17,6 +18,12 @@
 
 package org.apache.taglibs.standard.tag.common.xml;
 
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.jsp.JspException;
+import jakarta.servlet.jsp.JspTagException;
+import jakarta.servlet.jsp.PageContext;
+import jakarta.servlet.jsp.tagext.BodyTagSupport;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
@@ -24,14 +31,8 @@ import java.io.StringReader;
 import java.io.Writer;
 import java.util.List;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.jsp.JspException;
-import jakarta.servlet.jsp.JspTagException;
-import jakarta.servlet.jsp.PageContext;
-import jakarta.servlet.jsp.tagext.BodyTagSupport;
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
@@ -81,7 +82,6 @@ public abstract class TransformSupport extends BodyTagSupport {
     private Transformer t;			   // actual Transformer
     private TransformerFactory tf;		   // reusable factory
     private DocumentBuilder db;			   // reusable factory
-    private DocumentBuilderFactory dbf;		   // reusable factory
 
 
     //*********************************************************************
@@ -115,21 +115,9 @@ public abstract class TransformSupport extends BodyTagSupport {
 
 	//************************************
 	// Initialize
-
-	// set up our DocumentBuilderFactory if necessary
-	if (dbf == null) {
-	    dbf = DocumentBuilderFactory.newInstance();
-            dbf.setNamespaceAware(true);
-            dbf.setValidating(false);
-            try {
-                dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-            } catch (ParserConfigurationException e) {
-                throw new AssertionError("Parser does not support secure processing");
-            }
-	}
-        if (db == null)
-	    db = dbf.newDocumentBuilder();
-
+        if (db == null) {
+            db = DocumentBuilderProvider.createSecureDocumentBuilder();
+        }
 	// set up the TransformerFactory if necessary
         if (tf == null) {
             tf = TransformerFactory.newInstance();


### PR DESCRIPTION
Solution: partial cleanup in xml package.

- Maybe (!!!) fixes race condition in GlassFish. 
- Since this change the TCK jstl/spec/xml/xmlcore/types passed several times without failing. However, I am still not convinced, because the failure wasn't well reproducible and also the cause wasn't clearly visible.
- Updated dependencies
- XPathUtil doesn't set system properties any more.
- DocumentBuilderFactory should not be used as a constant, it is not thread-safe. Despite in this case I doubt it could cause issue, but I cannot be sure. EDIT: It can be used as a constant if it doesn't change. DocumentBuilder cannot.
- Deleted unused methods
- JSTLNodeList moved to own file
- Deleted copy pasted javadocs from old versions
- More should be done, but let's start with this.

`cd /repo/git/jstl && mvn clean install && cd /repo/git/glassfish-beta && mvn clean install -Pfastest -T4C -Djstl-impl.version=3.0.1-SNAPSHOT && mvn clean install -Ptck -pl :tck-runner -Dit.test=CustomITest -Dtck.module=jstl`

Or to run those randomly failing tests directly use `-Dtck.module=jstl/spec/xml/xmlcore/types`

Note: I tried to replace the JSTLXPathFactory by the factory from the JDK, but that failed, it needs more work, perhaps later.

TCK results with GlassFish 7.0.0-SNAPSHOT near to M9, commit e821a1a6a86fce6daa06db203bdd7676231bbec7
```
[runcts] OUT => [javatest.batch] Total time = 1,423s
[runcts] OUT => [javatest.batch] Setup time = 0s
[runcts] OUT => [javatest.batch] Cleanup time = 2s
[runcts] OUT => [javatest.batch] Test results: passed: 541
```