### PR TITLE
Drop wagon-svn build extension

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,12 +171,6 @@
               </executions>
           </plugin>
         </plugins>
-        <extensions>
-            <extension>
-                <groupId>org.jvnet.wagon-svn</groupId>
-                <artifactId>wagon-svn</artifactId>
-            </extension>
-        </extensions>
     </build>
 
     <reporting>


### PR DESCRIPTION
I'm pretty sure there is no need to download and load this into maven.