### PR TITLE
Add canonical link for increased spec discoverability 

### DIFF
--- a/spec/src/main/asciidoc/docinfo.html
+++ b/spec/src/main/asciidoc/docinfo.html
@@ -1,0 +1,2 @@
+<!-- revnumber comes from plugin configuration -->
+<link rel="canonical" href="https://jakarta.ee/specifications/tags/{revnumber}/jakarta-tags-spec-{revnumber}" />

--- a/spec/src/main/asciidoc/jakarta-stl-spec.adoc
+++ b/spec/src/main/asciidoc/jakarta-stl-spec.adoc
@@ -1,12 +1,24 @@
-//
 // Copyright (c) 2017, 2019 Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2019, 2025 Contributors to the Eclipse Foundation
 //
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 = Jakarta Standard Tag Library
 :authors: Jakarta Standard Tag Library Team, https://projects.eclipse.org/projects/ee4j.jstl
 :email: https://dev.eclipse.org/mailman/listinfo/jstl-dev
 :version-label!:
 :doctype: book
+:docinfo: shared
 :license: Eclipse Foundation Specification License v1.0
 :source-highlighter: coderay
 :toc: left


### PR DESCRIPTION
See more details here : `https://github.com/jakartaee/platform/issues/1108` 

This will be built and included in the specification project 