### PR TITLE
[2653][platform-tck challenge] Do not use the java.version system pro…

### DIFF
--- a/tck/src/main/java/com/sun/ts/tests/jstl/common/client/AbstractUrlClient.java
+++ b/tck/src/main/java/com/sun/ts/tests/jstl/common/client/AbstractUrlClient.java
@@ -231,18 +231,7 @@ public class AbstractUrlClient extends BaseUrlClient {
     }
 
     public boolean isJavaVersion20OrGreater() {
-        boolean isJavaVersion20OrGreater = false;
-
-        String version = System.getProperty("java.version");
-        int majorVersionDot = version.indexOf(".");
-
-        version = version.substring(0, majorVersionDot);
-
-        if (Integer.parseInt(version) >= 20) {
-            isJavaVersion20OrGreater = true;
-        }
-
-        return isJavaVersion20OrGreater;
+        return Runtime.version().feature() >= 20;
     }
 
 }


### PR DESCRIPTION
…perty when attempting to determine the Java version. Instead use the Runtime.version() in the Jakarta Tags TCK.

fixes https://github.com/jakartaee/platform-tck/issues/2653

The downstream fix was filed against the EE11 TCK in #2654