### PR TITLE
Fix bnd plugin `Import-Package` instructions

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -206,9 +206,9 @@
                         <Implementation-Vendor-Id>org.glassfish</Implementation-Vendor-Id>
                         <Import-Package>
                             <!-- Requires EE12 (or any other minor releases with API compatibility), but can still allow EE11 -->
-                            jakarta.el;version="[6.0,7)"
-                            jakarta.servlet;version="[6.1,7)"
-                            jakarta.servlet.http;version="[6.1,7)"
+                            jakarta.el;version="[6.0,7)",
+                            jakarta.servlet;version="[6.1,7)",
+                            jakarta.servlet.http;version="[6.1,7)",
                             jakarta.servlet.jsp;version="[4.0,5)",
                             *
                         </Import-Package>


### PR DESCRIPTION
I think this could introduce following change in manifest:

```diff
--- MANIFEST.MF
+++ MANIFEST.MF
@@ -20,9 +20,9 @@
 Implementation-Vendor: Eclipse Foundation
 Implementation-Vendor-Id: org.glassfish
 Implementation-Version: 3.1.0
-Import-Package: jakarta.el;version="[4.0,5)",jakarta.servlet;version="[6
- .0,7)",jakarta.servlet.http;version="[6.0,7)",jakarta.servlet.jsp;versi
- on="[3.1,4)",jakarta.servlet.jsp.jstl.core,jakarta.servlet.jsp.tagext;v
+Import-Package: jakarta.el;version="[6.0,7)",jakarta.servlet;version="[6
+ .1,7)",jakarta.servlet.http;version="[6.1,7)",jakarta.servlet.jsp;versi
+ on="[4.0,5)",jakarta.servlet.jsp.jstl.core,jakarta.servlet.jsp.tagext;v
  ersion="[3.1,4)",java.io,java.lang,java.lang.invoke,java.sql,java.text,
  java.util,javax.xml.parsers,org.xml.sax,org.xml.sax.helpers
 Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=21))"
```


- https://github.com/jakartaee/tags/issues/289#issuecomment-4716492801
- https://github.com/jakartaee/tags/pull/277