### PR TITLE
TCK: Use region timezone IDs to eliminate timezone deprecation warnings when running with JDK 25

### DIFF
--- a/tck/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/JSTLClientIT.java
+++ b/tck/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/JSTLClientIT.java
@@ -757,7 +757,7 @@ public class JSTLClientIT extends CompatAbstractUrlClient {
      * @assertion_ids: JSTL:SPEC:57.1; JSTL:SPEC:57.1.1; JSTL:SPEC:57.1.2; JSTL:SPEC:57.1.3
      * 
      * @testStrategy: Validate that the value attribute can accept both static values as well as three letter timezones (ex.
-     * PST) or fully qualified values (ex. America/Los_Angeles).
+     * America/Los_Angeles).
      */
     @Test
     public void positiveSetTimezoneValueTest() throws Exception {
@@ -779,7 +779,7 @@ public class JSTLClientIT extends CompatAbstractUrlClient {
      * @assertion_ids: JSTL:SPEC:57.1; JSTL:SPEC:57.1.1; JSTL:SPEC:57.1.2; JSTL:SPEC:57.1.3
      * 
      * @testStrategy: Validate that the value attribute can accept both static values as well as three letter timezones (ex.
-     * PST) or fully qualified values (ex. America/Los_Angeles).
+     * America/Los_Angeles).
      */
     @Test
     public void positiveTimezoneValueTest() throws Exception {

--- a/tck/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/JSTLClientIT.java
+++ b/tck/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/JSTLClientIT.java
@@ -235,7 +235,7 @@ public class JSTLClientIT extends AbstractUrlClient {
      * @assertion_ids: JSTL:SPEC:57.11
      * 
      * @testStrategy: Validate that if timeZone is null or empty, the value will be formatted as if it was present. In this
-     * case, the time will be formatted using the page's time zone of EST.
+     * case, the time will be formatted using the page's time zone of America/New_York.
      */
     @Test
     public void positiveFDTimeZoneNullEmptyTest() throws Exception {

--- a/tck/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/JSTLClientIT.java
+++ b/tck/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/JSTLClientIT.java
@@ -457,7 +457,7 @@ public class JSTLClientIT extends AbstractUrlClient {
      * @assertion_ids: JSTL:SPEC:58.25
      * 
      * @testStrategy: Validate that if timeZone is null or empty, the value will be formatted as if it was missing. In this
-     * case, the time will be formatted using the page's time zone of EST. Pass the parsed value to formatDate to display
+     * case, the time will be formatted using the page's time zone of America/New_York. Pass the parsed value to formatDate to display
      * (due to possible timezone difference).
      */
     @Test

--- a/tck/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/JSTLClientIT.java
+++ b/tck/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/JSTLClientIT.java
@@ -79,7 +79,7 @@ public class JSTLClientIT extends AbstractUrlClient {
      * JSTL:SPEC:93.1.5; JSTL:SPEC:93.1.6
      * 
      * @testStrategy: Validate that the value attribute can accept dynamic values as well as three letter timezones (ex.
-     * PST) or fully qualified values (ex. America/Los_Angeles).
+     * America/Los_Angeles).
      */
     @Test
     public void positiveSetTimezoneValueTest() throws Exception {

--- a/tck/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/timezone/JSTLClientIT.java
+++ b/tck/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/timezone/JSTLClientIT.java
@@ -64,7 +64,7 @@ public class JSTLClientIT extends AbstractUrlClient {
      * @assertion_ids: JSTL:SPEC:54; JSTL:SPEC:54.1; JSTL:SPEC:54.1.1; JSTL:SPEC:54.1.2; JSTL:SPEC:54.1.3
      * 
      * @testStrategy: Validate that the value attribute can accept both static values as well as three letter timezones (ex.
-     * PST) or fully qualified values (ex. America/Los_Angeles).
+     * America/Los_Angeles).
      */
     @Test
     public void positiveTimezoneValueTest() throws Exception {

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFDValueTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFDValueTest.jsp
@@ -27,7 +27,7 @@
         pageContext.setAttribute("dte", date);
     %>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <!-- EL: Validate the the action can properly format a date
              Date -->
     <fmt:formatDate value="${dte}"/><br>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTest.jsp
@@ -26,7 +26,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setBundle basename="com.sun.ts.tests.jstl.common.resources.Resources1"/>
     <fmt:setLocale value="de_DE"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
@@ -28,7 +28,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setBundle basename="com.sun.ts.tests.jstl.common.resources.Resources1"/>
     <fmt:setLocale value="de_DE"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positivePDValueTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positivePDValueTest.jsp
@@ -23,7 +23,7 @@
 <tck:test testName="positivePDValueTest">
     <c:set var="dte" value="Nov 21, 2000"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <!-- EL: Validate the the action can properly parse a date
              provided as a dynamic or static value. -->
     <fmt:parseDate value="${dte}" var="e1"/>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveSetTimezoneValueTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveSetTimezoneValueTest.jsp
@@ -25,12 +25,12 @@
 <%@ page import="java.util.TimeZone,java.util.Date" %>
 <tck:test testName="positiveTimezoneValueTest">
    <%
-        TimeZone tz = TimeZone.getTimeZone("PST");
+        TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
         pageContext.setAttribute("tz", tz);
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <c:set var="mtz" value="PST"/>
+    <c:set var="mtz" value="America/Los_Angeles"/>
     <!-- EL: Behavioral test of value attribute -->
     <!-- Timezone object -->
     <fmt:setTimeZone value="${tz}"/>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveTimezoneValueTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveTimezoneValueTest.jsp
@@ -25,12 +25,12 @@
 <%@ page import="java.util.TimeZone,java.util.Date" %>
 <tck:test testName="positiveTimezoneValueTest">
     <%
-        TimeZone tz = TimeZone.getTimeZone("PST");
+        TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
         pageContext.setAttribute("tz", tz);
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <c:set var="mtz" value="PST"/>
+    <c:set var="mtz" value="America/Los_Angeles"/>
     <!-- EL: Behavioral test of value attribute -->
     <!-- Timezone object -->
     <fmt:timeZone value="${tz}">

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTest.jsp
@@ -34,7 +34,7 @@
     <c:set var="lon" value="long"/>
     <c:set var="ful" value="full"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
      <!-- dateStyle specifies what date style the formated value
              will be returned in.  This will only be applied

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDFallbackLocaleTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDFallbackLocaleTest.jsp
@@ -27,7 +27,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <tck:config op="set" configVar="fallback" value="en-US"/>
     <!-- The fallbackLocale configuration variable will be
              used if no locale match can be determined. -->

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDLocalizationContextTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDLocalizationContextTest.jsp
@@ -27,7 +27,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setBundle basename="com.sun.ts.tests.jstl.common.resources.Resources"/>
 
     <!-- Validate that the action is able to dermine the

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDPatternTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDPatternTest.jsp
@@ -28,7 +28,7 @@
     %>
     <c:set var="pat" value="yyyy.MM.dd G 'at' HH:mm:ss z"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- the pattern attribute specifies a custom pattern
              to be applied when formatting the provided date. -->

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDScopeTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDScopeTest.jsp
@@ -27,7 +27,7 @@
         pageContext.setAttribute("dte", date);
     %>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- The presence of the scope attribute will cause var to be
              exported to the available scopes of the PageContext.

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTest.jsp
@@ -34,7 +34,7 @@
     <c:set var="lon" value="long"/>
     <c:set var="ful" value="full"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
      <!-- timeStyle specifies what time style the formated value
              will be returned in.  This will only be applied

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneNullEmptyTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneNullEmptyTest.jsp
@@ -28,7 +28,7 @@
         pageContext.setAttribute("dte", date);
     %>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- If timeZone is null or empty, it will be treated as
              if it was not present. -->

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTest.gf
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTest.gf
@@ -15,22 +15,22 @@
                 value.
               - Use the value of the scoped attribute
                 jakarta.servlet.jsp.jstl.fmt.timeZone. -->
-    <br>TimeZone attribute specified with a value of PST:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be 7:11:34 PM:<br>
+    <br>TimeZone attribute specified with a value of America/Los_Angeles:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be 7:11:34 PM:<br>
       
         Dec 26, 1997, 7:11:34 PM<br>
       
 
-      Not wrapped.  Page has a time zone of EST.  Time should be 7:11:34 PM<br>
+      Not wrapped.  Page has a time zone of America/New_York.  Time should be 7:11:34 PM<br>
       Dec 26, 1997, 7:11:34 PM<br>
 
     <br>No TimeZone attribute specified:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be 8:11:34 PM:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be 8:11:34 PM:<br>
       
         Dec 26, 1997, 8:11:34 PM<br>
       
 
-      Not wrapped.  Page has a time zone of EST.  Time should be 10:11:34 PM<br>
+      Not wrapped.  Page has a time zone of America/New_York.  Time should be 10:11:34 PM<br>
       Dec 26, 1997, 10:11:34 PM<br>
     <br>
 

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTest.jsp
@@ -27,7 +27,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setLocale value="en_US"/>
 
     <!--  The time zone to be used when formatting operates
@@ -37,22 +37,22 @@
                 value.
               - Use the value of the scoped attribute
                 jakarta.servlet.jsp.jstl.fmt.timeZone. -->
-    <br>TimeZone attribute specified with a value of PST:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be 7:11:34 PM:<br>
-      <fmt:timeZone value="MST">
-        <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' timeZone="PST" type="both"/><br>
+    <br>TimeZone attribute specified with a value of America/Los_Angeles:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be 7:11:34 PM:<br>
+      <fmt:timeZone value="America/Denver">
+        <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' timeZone="America/Los_Angeles" type="both"/><br>
       </fmt:timeZone>
 
-      Not wrapped.  Page has a time zone of EST.  Time should be 7:11:34 PM<br>
-      <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' timeZone="PST" type="both"/><br>
+      Not wrapped.  Page has a time zone of America/New_York.  Time should be 7:11:34 PM<br>
+      <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' timeZone="America/Los_Angeles" type="both"/><br>
 
     <br>No TimeZone attribute specified:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be 8:11:34 PM:<br>
-      <fmt:timeZone value="MST">
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be 8:11:34 PM:<br>
+      <fmt:timeZone value="America/Denver">
         <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' type="both"/><br>
       </fmt:timeZone>
 
-      Not wrapped.  Page has a time zone of EST.  Time should be 10:11:34 PM<br>
+      Not wrapped.  Page has a time zone of America/New_York.  Time should be 10:11:34 PM<br>
       <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' type="both"/><br>
     <br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTestJava20Plus.gf
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTestJava20Plus.gf
@@ -15,22 +15,22 @@
                 value.
               - Use the value of the scoped attribute
                 jakarta.servlet.jsp.jstl.fmt.timeZone. -->
-    <br>TimeZone attribute specified with a value of PST:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be 7:11:34 PM:<br>
+    <br>TimeZone attribute specified with a value of America/Los_Angeles:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be 7:11:34 PM:<br>
       
         Dec 26, 1997, 7:11:34 PM<br>
       
 
-      Not wrapped.  Page has a time zone of EST.  Time should be 7:11:34 PM<br>
+      Not wrapped.  Page has a time zone of America/New_York.  Time should be 7:11:34 PM<br>
       Dec 26, 1997, 7:11:34 PM<br>
 
     <br>No TimeZone attribute specified:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be 8:11:34 PM:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be 8:11:34 PM:<br>
       
         Dec 26, 1997, 8:11:34 PM<br>
       
 
-      Not wrapped.  Page has a time zone of EST.  Time should be 10:11:34 PM<br>
+      Not wrapped.  Page has a time zone of America/New_York.  Time should be 10:11:34 PM<br>
       Dec 26, 1997, 10:11:34 PM<br>
     <br>
 

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTest.gf
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTest.gf
@@ -10,7 +10,7 @@
 
     <!-- The time zone to be applied to the formatted value can                   be explicitly provided to the action.  This will effectively
              overried the timezone of the page -->
-    <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be minus 3 hours.<br>
+    <br>Page is using America/New_York for the timezone.  The formatting action will use America/Los_Angeles.  Value should be minus 3 hours.<br>
     No timeZone attribute: Dec 26, 1997, 10:11:34 PM<br>
     Dec 26, 1997, 7:11:34 PM<br>
     Dec 26, 1997, 7:11:34 PM<br>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTest.jsp
@@ -26,18 +26,18 @@
     <%  
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
-        pageContext.setAttribute("tz", TimeZone.getTimeZone("PST"));
+        pageContext.setAttribute("tz", TimeZone.getTimeZone("America/Los_Angeles"));
     %>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- The time zone to be applied to the formatted value can
              be explicitly provided to the action.  This will effectively
              overried the timezone of the page -->
-    <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be minus 3 hours.<br>
+    <br>Page is using America/New_York for the timezone.  The formatting action will use America/Los_Angeles.  Value should be minus 3 hours.<br>
     No timeZone attribute: <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' type="both"/><br>
     <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>'
                        timeZone='<%= (TimeZone) pageContext.getAttribute("tz") %>' type="both"/><br>
     <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>'
-                       timeZone="PST" type="both"/><br>
+                       timeZone="America/Los_Angeles" type="both"/><br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTestJava20Plus.gf
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTestJava20Plus.gf
@@ -10,7 +10,7 @@
 
     <!-- The time zone to be applied to the formatted value can                   be explicitly provided to the action.  This will effectively
              overried the timezone of the page -->
-    <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be minus 3 hours.<br>
+    <br>Page is using America/New_York for the timezone.  The formatting action will use America/Los_Angeles.  Value should be minus 3 hours.<br>
     No timeZone attribute: Dec 26, 1997, 10:11:34 PM<br>
     Dec 26, 1997, 7:11:34 PM<br>
     Dec 26, 1997, 7:11:34 PM<br>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTypeTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTypeTest.jsp
@@ -32,7 +32,7 @@
     <c:set var="dat" value="date"/>
     <c:set var="bot" value="both"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- the type attribute specifies if either the time or date
              or both components of the provided date value will

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDValueNullTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDValueNullTest.jsp
@@ -22,7 +22,7 @@
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positiveFDValueNullEmptyTest">
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- If value is null and var (or scope and var) is specified,
              the scoped variable identified by var is removed.  If 

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDValueTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDValueTest.jsp
@@ -26,7 +26,7 @@
         Date date = new Date(883192294202L);
     %>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- Validate the the action can properly format a date
              Date -->

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTest.jsp
@@ -26,7 +26,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>
 
     <!-- If the action is not wrapped in a fmt:bundle action,

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp
@@ -28,7 +28,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>
 
     <!-- If the action is not wrapped in a fmt:bundle action,

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTest.jsp
@@ -26,7 +26,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setBundle basename="com.sun.ts.tests.jstl.common.resources.AlgoResources6"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>
 

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.jsp
@@ -28,7 +28,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setBundle basename="com.sun.ts.tests.jstl.common.resources.AlgoResources6"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>
 

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTest.jsp
@@ -26,7 +26,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setBundle basename="com.sun.ts.tests.jstl.common.resources.Resources1"/>
     <fmt:setLocale value="de_DE"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
@@ -28,7 +28,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setBundle basename="com.sun.ts.tests.jstl.common.resources.Resources1"/>
     <fmt:setLocale value="de_DE"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTest.jsp
@@ -26,7 +26,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setLocale value="en_US"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>
 

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.jsp
@@ -28,7 +28,7 @@
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setLocale value="en_US"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>
 

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTest.jsp
@@ -21,13 +21,13 @@
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDBodyValueTest">
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- The date to be parsed can be provided as body content to the
               action. -->
     <fmt:parseDate type="both" var="e2">
         Nov 21, 2000, 3:45:02 AM
     </fmt:parseDate>
-    <fmt:formatDate value="${e2}" type="both" timeZone="EST"/>
+    <fmt:formatDate value="${e2}" type="both" timeZone="America/New_York"/>
 
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.jsp
@@ -23,13 +23,13 @@
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDBodyValueTest">
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- The date to be parsed can be provided as body content to the
               action. -->
     <fmt:parseDate type="both" var="e2">
         Nov 21, 2000, 3:45:02 AM
     </fmt:parseDate>
-    <fmt:formatDate value="${e2}" type="both" timeZone="EST"/>
+    <fmt:formatDate value="${e2}" type="both" timeZone="America/New_York"/>
 
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTest.jsp
@@ -27,7 +27,7 @@
     <c:set var="lon" value="long"/>
     <c:set var="ful" value="full"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
      <!-- dateStyle specifies the formatting style that determines how
              the provided value will be parsed. dateStyle should be

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTestJava20Plus.jsp
@@ -29,7 +29,7 @@
     <c:set var="lon" value="long"/>
     <c:set var="ful" value="full"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
      <!-- dateStyle specifies the formatting style that determines how
              the provided value will be parsed. dateStyle should be

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTest.jsp
@@ -22,7 +22,7 @@
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positivePDFallbackLocaleTest">
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <c:set var="dte" value="Nov 21, 2000"/>
     <c:set var="dtim" value="3:45:02 AM"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/> 
@@ -33,7 +33,7 @@
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' var="r1"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dtim") %>' type="time" var="r2"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>' type="both" var="r3"/>
-    <fmt:formatDate value="${r1}" timeZone="EST"/><br>
-    <fmt:formatDate value="${r2}" timeZone="EST" type="time"/><br>
-    <fmt:formatDate value="${r3}" timeZone="EST" type="both"/><br>
+    <fmt:formatDate value="${r1}" timeZone="America/New_York"/><br>
+    <fmt:formatDate value="${r2}" timeZone="America/New_York" type="time"/><br>
+    <fmt:formatDate value="${r3}" timeZone="America/New_York" type="both"/><br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.jsp
@@ -24,7 +24,7 @@
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
 <tck:test testName="positivePDFallbackLocaleTest">
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <c:set var="dte" value="Nov 21, 2000"/>
     <c:set var="dtim" value="3:45:02 AM"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/> 
@@ -35,7 +35,7 @@
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' var="r1"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dtim") %>' type="time" var="r2"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>' type="both" var="r3"/>
-    <fmt:formatDate value="${r1}" timeZone="EST"/><br>
-    <fmt:formatDate value="${r2}" timeZone="EST" type="time"/><br>
-    <fmt:formatDate value="${r3}" timeZone="EST" type="both"/><br>
+    <fmt:formatDate value="${r1}" timeZone="America/New_York"/><br>
+    <fmt:formatDate value="${r2}" timeZone="America/New_York" type="time"/><br>
+    <fmt:formatDate value="${r3}" timeZone="America/New_York" type="both"/><br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTest.jsp
@@ -21,7 +21,7 @@
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDLocalizationContextTest">
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <c:set var="dte" value="Nov 21, 2000"/>
     <c:set var="dtim" value="3:45:02 AM"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/> 
@@ -33,8 +33,8 @@
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' var="r1"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dtim") %>' type="time" var="r2"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>' type="both" var="r3"/>
-    <fmt:formatDate value="${r1}" timeZone="EST"/><br>
-    <fmt:formatDate value="${r2}" timeZone="EST" type="time"/><br>
-    <fmt:formatDate value="${r3}" timeZone="EST" type="both"/><br>
+    <fmt:formatDate value="${r1}" timeZone="America/New_York"/><br>
+    <fmt:formatDate value="${r2}" timeZone="America/New_York" type="time"/><br>
+    <fmt:formatDate value="${r3}" timeZone="America/New_York" type="both"/><br>
 
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.jsp
@@ -23,7 +23,7 @@
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDLocalizationContextTest">
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <c:set var="dte" value="Nov 21, 2000"/>
     <c:set var="dtim" value="3:45:02 AM"/>
     <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/> 
@@ -35,8 +35,8 @@
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' var="r1"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dtim") %>' type="time" var="r2"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>' type="both" var="r3"/>
-    <fmt:formatDate value="${r1}" timeZone="EST"/><br>
-    <fmt:formatDate value="${r2}" timeZone="EST" type="time"/><br>
-    <fmt:formatDate value="${r3}" timeZone="EST" type="both"/><br>
+    <fmt:formatDate value="${r1}" timeZone="America/New_York"/><br>
+    <fmt:formatDate value="${r2}" timeZone="America/New_York" type="time"/><br>
+    <fmt:formatDate value="${r3}" timeZone="America/New_York" type="both"/><br>
 
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleNullEmptyTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleNullEmptyTest.jsp
@@ -21,13 +21,13 @@
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <tck:test testName="positivePDParseLocaleNullEmptyTest">
     <fmt:setLocale value="en-US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- if parseLocale is null or empty, it is treated as if
              not specified. The locale configuration variable should be used.-->
     <fmt:parseDate value="Nov 21, 2000" parseLocale='<%= null %>' var="r1"/>
     <fmt:parseDate value="Nov 21, 2000" parseLocale="" var="r2"/>
-    <fmt:formatDate value="${r1}" timeZone="EST"/><br>
-    <fmt:formatDate value="${r2}" timeZone="EST"/><br>
+    <fmt:formatDate value="${r1}" timeZone="America/New_York"/><br>
+    <fmt:formatDate value="${r2}" timeZone="America/New_York"/><br>
 
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTest.jsp
@@ -28,7 +28,7 @@
     <c:set var="dte" value="Nov 21, 2000, 3:45:02 AM"/>
     <c:set var="us" value="en_US"/>
     <fmt:setLocale value="de_DE"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- parseLocale specifies the locale specific formatting pattern
              to apply when parsing the provided value.  The presence of this

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTestJava20Plus.jsp
@@ -30,7 +30,7 @@
     <c:set var="dte" value="Nov 21, 2000, 3:45:02 AM"/>
     <c:set var="us" value="en_US"/>
     <fmt:setLocale value="de_DE"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- parseLocale specifies the locale specific formatting pattern
              to apply when parsing the provided value.  The presence of this

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDPatternTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDPatternTest.jsp
@@ -22,9 +22,9 @@
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <tck:test testName="positivePDPatternTest">
     <c:set var="pat" value="yyyy.MM.dd G 'at' HH:mm:ss z"/>
-    <c:set var="dte" value="2000.11.21 AD at 03:45:02 EST"/>
+    <c:set var="dte" value="2000.11.21 AD at 03:45:02 GMT-05:00"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- the pattern attribute specifies a custom pattern
              to be applied when parsing the provided date. -->
@@ -32,6 +32,6 @@
                        pattern='<%= (String) pageContext.getAttribute("pat") %>' var="r1"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>'
                        pattern="yyyy.MM.dd G 'at' HH:mm:ss z" var="r2"/>
-    <fmt:formatDate value="${r1}" timeZone="EST" pattern="${pat}"/><br>
-    <fmt:formatDate value="${r2}" timeZone="EST" pattern="${pat}"/><br>
+    <fmt:formatDate value="${r1}" timeZone="America/New_York" pattern="${pat}"/><br>
+    <fmt:formatDate value="${r2}" timeZone="America/New_York" pattern="${pat}"/><br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTest.jsp
@@ -27,7 +27,7 @@
     <c:set var="lon" value="long"/>
     <c:set var="ful" value="full"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
      <!-- timeStyle specifies formatting style that determines how
              the provided value will be parsed. timeStyle should be
@@ -83,12 +83,12 @@
      <fmt:parseDate value="3:45:02 AM"
                        timeStyle='<%= (String) pageContext.getAttribute("med") %>' type="time"/><br>
      <fmt:parseDate value="3:45:03 AM" timeStyle="medium" type="time"/><br>
-     <fmt:parseDate value="3:45:03 AM EST"
+     <fmt:parseDate value="3:45:03 AM GMT-05:00"
                        timeStyle='<%= (String) pageContext.getAttribute("lon") %>' type="time"/><br>
-     <fmt:parseDate value="3:45:03 AM EST" timeStyle="long" type="time"/><br>
-     <fmt:parseDate value="3:45:03 AM EST"
+     <fmt:parseDate value="3:45:03 AM GMT-05:00" timeStyle="long" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM GMT-05:00"
                        timeStyle='<%= (String) pageContext.getAttribute("ful") %>' type="time"/><br>
-     <fmt:parseDate value="3:45:03 AM EST" timeStyle="full" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM GMT-05:00" timeStyle="full" type="time"/><br>
 
      <br>'type' set to 'both' -- timeStyle should be applied.<br>
      <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" type="both"/><br>
@@ -102,11 +102,11 @@
      <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM"
                        timeStyle='<%= (String) pageContext.getAttribute("med") %>' type="both"/><br>
      <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" timeStyle="medium" type="both"/><br>
-     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST"
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM GMT-05:00"
                        timeStyle='<%= (String) pageContext.getAttribute("lon") %>' type="both"/><br>
-     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST" timeStyle="long" type="both"/><br>
-     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST"
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM GMT-05:00" timeStyle="long" type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM GMT-05:00"
                        timeStyle='<%= (String) pageContext.getAttribute("ful") %>' type="both"/><br>
-     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST"
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM GMT-05:00"
                        timeStyle="full" type="both"/><br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTestJava20Plus.jsp
@@ -29,7 +29,7 @@
     <c:set var="lon" value="long"/>
     <c:set var="ful" value="full"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
      <!-- timeStyle specifies formatting style that determines how
              the provided value will be parsed. timeStyle should be
@@ -85,12 +85,12 @@
      <fmt:parseDate value="3:45:02 AM"
                        timeStyle='<%= (String) pageContext.getAttribute("med") %>' type="time"/><br>
      <fmt:parseDate value="3:45:03 AM" timeStyle="medium" type="time"/><br>
-     <fmt:parseDate value="3:45:03 AM EST"
+     <fmt:parseDate value="3:45:03 AM GMT-05:00"
                        timeStyle='<%= (String) pageContext.getAttribute("lon") %>' type="time"/><br>
-     <fmt:parseDate value="3:45:03 AM EST" timeStyle="long" type="time"/><br>
-     <fmt:parseDate value="3:45:03 AM EST"
+     <fmt:parseDate value="3:45:03 AM GMT-05:00" timeStyle="long" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM GMT-05:00"
                        timeStyle='<%= (String) pageContext.getAttribute("ful") %>' type="time"/><br>
-     <fmt:parseDate value="3:45:03 AM EST" timeStyle="full" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM GMT-05:00" timeStyle="full" type="time"/><br>
 
      <br>'type' set to 'both' -- timeStyle should be applied.<br>
      <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" type="both"/><br>
@@ -104,11 +104,11 @@
      <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM"
                        timeStyle='<%= (String) pageContext.getAttribute("med") %>' type="both"/><br>
      <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" timeStyle="medium" type="both"/><br>
-     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST"
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM GMT-05:00"
                        timeStyle='<%= (String) pageContext.getAttribute("lon") %>' type="both"/><br>
-     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST" timeStyle="long" type="both"/><br>
-     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST"
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM GMT-05:00" timeStyle="long" type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM GMT-05:00"
                        timeStyle='<%= (String) pageContext.getAttribute("ful") %>' type="both"/><br>
-     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST"
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM GMT-05:00"
                        timeStyle="full" type="both"/><br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTest.jsp
@@ -23,7 +23,7 @@
 <tck:test testName="positivePDTimeZoneNullEmptyTest">
     <c:set var="dt" value="Nov 21, 2000, 3:45 AM"/> 
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="MST"/>
+    <fmt:setTimeZone value="America/Denver"/>
 
     <!-- If timeZone is null or empty, it will be treated as
              if it was not present (only type short times is specified
@@ -32,6 +32,6 @@
                        timeZone='<%= null %>' type="both" timeStyle="short" var="rn1"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>'
                        timeZone="" type="both" timeStyle="short" var="re1"/>
-    <fmt:formatDate value="${rn1}" timeZone="EST" type="both" timeStyle="short"/><br>
-    <fmt:formatDate value="${re1}" timeZone="EST" type="both" timeStyle="short"/><br>
+    <fmt:formatDate value="${rn1}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
+    <fmt:formatDate value="${re1}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.jsp
@@ -25,7 +25,7 @@
 <tck:test testName="positivePDTimeZoneNullEmptyTest">
     <c:set var="dt" value="Nov 21, 2000, 3:45 AM"/> 
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="MST"/>
+    <fmt:setTimeZone value="America/Denver"/>
 
     <!-- If timeZone is null or empty, it will be treated as
              if it was not present (only type short times is specified
@@ -34,6 +34,6 @@
                        timeZone='<%= null %>' type="both" timeStyle="short" var="rn1"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>'
                        timeZone="" type="both" timeStyle="short" var="re1"/>
-    <fmt:formatDate value="${rn1}" timeZone="EST" type="both" timeStyle="short"/><br>
-    <fmt:formatDate value="${re1}" timeZone="EST" type="both" timeStyle="short"/><br>
+    <fmt:formatDate value="${rn1}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
+    <fmt:formatDate value="${re1}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTest.gf
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTest.gf
@@ -16,25 +16,25 @@
                 value.
               - Use the value of the scoped attribute
                 jakarta.servlet.jsp.jstl.fmt.timeZone. -->
-    <br>TimeZone attribute specified with a value of PST:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 3 hours:<br>
+    <br>TimeZone attribute specified with a value of America/Los_Angeles:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be offset by 3 hours:<br>
       
         
       
       Nov 21, 2000, 6:45 AM<br>
 
-      Not wrapped.  Page has a time zone of EST, timeZone attribute specified.  Time should be offset by 3 hours:<br>
+      Not wrapped.  Page has a time zone of America/New_York, timeZone attribute specified.  Time should be offset by 3 hours:<br>
       <br>
       Nov 21, 2000, 6:45 AM<br>
 
     <br>No TimeZone attribute specified:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 2 hours:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be offset by 2 hours:<br>
       
         <br>
       
       Nov 21, 2000, 5:45 AM<br>
       
-      Not wrapped.  Page has a time zone of EST.  Time should not be offset:<br>
+      Not wrapped.  Page has a time zone of America/New_York.  Time should not be offset:<br>
       <br>
       Nov 21, 2000, 3:45 AM<br>
     <br>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTest.jsp
@@ -23,7 +23,7 @@
 <%@ page import="java.util.Date" %>
 <tck:test testName="positivePDTimeZonePrecedenceTest">
     <c:set var="dte" value="Nov 21, 2000, 3:45 AM"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setLocale value="en_US"/>
 
     <!--  The time zone to be used when formatting operates
@@ -33,26 +33,26 @@
                 value.
               - Use the value of the scoped attribute
                 jakarta.servlet.jsp.jstl.fmt.timeZone. -->
-    <br>TimeZone attribute specified with a value of PST:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 3 hours:<br>
-      <fmt:timeZone value="MST">
-        <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' timeZone="PST" type="both" timeStyle="short" var="rd1"/>
+    <br>TimeZone attribute specified with a value of America/Los_Angeles:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be offset by 3 hours:<br>
+      <fmt:timeZone value="America/Denver">
+        <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' timeZone="America/Los_Angeles" type="both" timeStyle="short" var="rd1"/>
       </fmt:timeZone>
-      <fmt:formatDate value="${rd1}" timeZone="EST" type="both" timeStyle="short"/><br>
+      <fmt:formatDate value="${rd1}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
 
-      Not wrapped.  Page has a time zone of EST, timeZone attribute specified.  Time should be offset by 3 hours:<br>
-      <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' timeZone="PST" type="both" timeStyle="short" var="rd2"/><br>
-      <fmt:formatDate value="${rd2}" timeZone="EST" type="both" timeStyle="short"/><br>
+      Not wrapped.  Page has a time zone of America/New_York, timeZone attribute specified.  Time should be offset by 3 hours:<br>
+      <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' timeZone="America/Los_Angeles" type="both" timeStyle="short" var="rd2"/><br>
+      <fmt:formatDate value="${rd2}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
 
     <br>No TimeZone attribute specified:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 2 hours:<br>
-      <fmt:timeZone value="MST">
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be offset by 2 hours:<br>
+      <fmt:timeZone value="America/Denver">
         <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' type="both" timeStyle="short" var="rd3"/><br>
       </fmt:timeZone>
-      <fmt:formatDate value="${rd3}" timeZone="EST" type="both" timeStyle="short"/><br>
+      <fmt:formatDate value="${rd3}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
       
-      Not wrapped.  Page has a time zone of EST.  Time should not be offset:<br>
+      Not wrapped.  Page has a time zone of America/New_York.  Time should not be offset:<br>
       <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' type="both" timeStyle="short" var="rd4"/><br>
-      <fmt:formatDate value="${rd4}" timeZone="EST" type="both" timeStyle="short"/><br>
+      <fmt:formatDate value="${rd4}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
     <br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.gf
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.gf
@@ -16,25 +16,25 @@
                 value.
               - Use the value of the scoped attribute
                 jakarta.servlet.jsp.jstl.fmt.timeZone. -->
-    <br>TimeZone attribute specified with a value of PST:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 3 hours:<br>
+    <br>TimeZone attribute specified with a value of America/Los_Angeles:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be offset by 3 hours:<br>
       
         
       
       Nov 21, 2000, 6:45 AM<br>
 
-      Not wrapped.  Page has a time zone of EST, timeZone attribute specified.  Time should be offset by 3 hours:<br>
+      Not wrapped.  Page has a time zone of America/New_York, timeZone attribute specified.  Time should be offset by 3 hours:<br>
       <br>
       Nov 21, 2000, 6:45 AM<br>
 
     <br>No TimeZone attribute specified:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 2 hours:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be offset by 2 hours:<br>
       
         <br>
       
       Nov 21, 2000, 5:45 AM<br>
       
-      Not wrapped.  Page has a time zone of EST.  Time should not be offset:<br>
+      Not wrapped.  Page has a time zone of America/New_York.  Time should not be offset:<br>
       <br>
       Nov 21, 2000, 3:45 AM<br>
     <br>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.jsp
@@ -25,7 +25,7 @@
 <%@ page import="java.util.Date" %>
 <tck:test testName="positivePDTimeZonePrecedenceTest">
     <c:set var="dte" value="Nov 21, 2000, 3:45 AM"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
     <fmt:setLocale value="en_US"/>
 
     <!--  The time zone to be used when formatting operates
@@ -35,26 +35,26 @@
                 value.
               - Use the value of the scoped attribute
                 jakarta.servlet.jsp.jstl.fmt.timeZone. -->
-    <br>TimeZone attribute specified with a value of PST:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 3 hours:<br>
-      <fmt:timeZone value="MST">
-        <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' timeZone="PST" type="both" timeStyle="short" var="rd1"/>
+    <br>TimeZone attribute specified with a value of America/Los_Angeles:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be offset by 3 hours:<br>
+      <fmt:timeZone value="America/Denver">
+        <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' timeZone="America/Los_Angeles" type="both" timeStyle="short" var="rd1"/>
       </fmt:timeZone>
-      <fmt:formatDate value="${rd1}" timeZone="EST" type="both" timeStyle="short"/><br>
+      <fmt:formatDate value="${rd1}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
 
-      Not wrapped.  Page has a time zone of EST, timeZone attribute specified.  Time should be offset by 3 hours:<br>
-      <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' timeZone="PST" type="both" timeStyle="short" var="rd2"/><br>
-      <fmt:formatDate value="${rd2}" timeZone="EST" type="both" timeStyle="short"/><br>
+      Not wrapped.  Page has a time zone of America/New_York, timeZone attribute specified.  Time should be offset by 3 hours:<br>
+      <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' timeZone="America/Los_Angeles" type="both" timeStyle="short" var="rd2"/><br>
+      <fmt:formatDate value="${rd2}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
 
     <br>No TimeZone attribute specified:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 2 hours:<br>
-      <fmt:timeZone value="MST">
+      Wrapped by &lt;fmt:timeZone&gt; action with America/Denver.  Time should be offset by 2 hours:<br>
+      <fmt:timeZone value="America/Denver">
         <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' type="both" timeStyle="short" var="rd3"/><br>
       </fmt:timeZone>
-      <fmt:formatDate value="${rd3}" timeZone="EST" type="both" timeStyle="short"/><br>
+      <fmt:formatDate value="${rd3}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
       
-      Not wrapped.  Page has a time zone of EST.  Time should not be offset:<br>
+      Not wrapped.  Page has a time zone of America/New_York.  Time should not be offset:<br>
       <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' type="both" timeStyle="short" var="rd4"/><br>
-      <fmt:formatDate value="${rd4}" timeZone="EST" type="both" timeStyle="short"/><br>
+      <fmt:formatDate value="${rd4}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
     <br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTest.gf
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTest.gf
@@ -12,7 +12,7 @@
     <!-- The time zone to be applied to the formatted value can
              be explicitly provided to the action.  This will effectively
              overried the timezone of the page -->
-    <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be offset 3 hours.<br>
+    <br>Page is using America/New_York for the timezone.  The formatting action will use America/Los_Angeles.  Value should be offset 3 hours.<br>
     
     
     

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTest.jsp
@@ -23,22 +23,22 @@
 <%@ page import="java.util.TimeZone" %>
 <tck:test testName="positivePDTimeZoneTest">
     <%
-        pageContext.setAttribute("tz", TimeZone.getTimeZone("PST"));
+        pageContext.setAttribute("tz", TimeZone.getTimeZone("America/Los_Angeles"));
     %>
     <c:set var="dte" value="Nov 21, 2000, 3:45 AM"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- The time zone to be applied to the formatted value can
              be explicitly provided to the action.  This will effectively
              overried the timezone of the page -->
-    <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be offset 3 hours.<br>
+    <br>Page is using America/New_York for the timezone.  The formatting action will use America/Los_Angeles.  Value should be offset 3 hours.<br>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' type="both" timeStyle="short" var="rdef"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>'
                        timeZone='<%= (TimeZone) pageContext.getAttribute("tz") %>' type="both" timeStyle="short" var="rpst1"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>'
-                       timeZone="PST" type="both" timeStyle="short" var="rpst2"/>
-    No timeZone attribute: <fmt:formatDate value="${rdef}" timeZone="EST" type="both" timeStyle="short"/><br>
-    <fmt:formatDate value="${rpst1}" timeZone="EST" type="both" timeStyle="short"/><br>
-    <fmt:formatDate value="${rpst2}" timeZone="EST" type="both" timeStyle="short"/><br>
+                       timeZone="America/Los_Angeles" type="both" timeStyle="short" var="rpst2"/>
+    No timeZone attribute: <fmt:formatDate value="${rdef}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
+    <fmt:formatDate value="${rpst1}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
+    <fmt:formatDate value="${rpst2}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.gf
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.gf
@@ -12,7 +12,7 @@
     <!-- The time zone to be applied to the formatted value can
              be explicitly provided to the action.  This will effectively
              overried the timezone of the page -->
-    <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be offset 3 hours.<br>
+    <br>Page is using America/New_York for the timezone.  The formatting action will use America/Los_Angeles.  Value should be offset 3 hours.<br>
     
     
     

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.jsp
@@ -25,22 +25,22 @@
 <%@ page import="java.util.TimeZone" %>
 <tck:test testName="positivePDTimeZoneTest">
     <%
-        pageContext.setAttribute("tz", TimeZone.getTimeZone("PST"));
+        pageContext.setAttribute("tz", TimeZone.getTimeZone("America/Los_Angeles"));
     %>
     <c:set var="dte" value="Nov 21, 2000, 3:45 AM"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- The time zone to be applied to the formatted value can
              be explicitly provided to the action.  This will effectively
              overried the timezone of the page -->
-    <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be offset 3 hours.<br>
+    <br>Page is using America/New_York for the timezone.  The formatting action will use America/Los_Angeles.  Value should be offset 3 hours.<br>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' type="both" timeStyle="short" var="rdef"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>'
                        timeZone='<%= (TimeZone) pageContext.getAttribute("tz") %>' type="both" timeStyle="short" var="rpst1"/>
     <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>'
-                       timeZone="PST" type="both" timeStyle="short" var="rpst2"/>
-    No timeZone attribute: <fmt:formatDate value="${rdef}" timeZone="EST" type="both" timeStyle="short"/><br>
-    <fmt:formatDate value="${rpst1}" timeZone="EST" type="both" timeStyle="short"/><br>
-    <fmt:formatDate value="${rpst2}" timeZone="EST" type="both" timeStyle="short"/><br>
+                       timeZone="America/Los_Angeles" type="both" timeStyle="short" var="rpst2"/>
+    No timeZone attribute: <fmt:formatDate value="${rdef}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
+    <fmt:formatDate value="${rpst1}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
+    <fmt:formatDate value="${rpst2}" timeZone="America/New_York" type="both" timeStyle="short"/><br>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTest.jsp
@@ -28,7 +28,7 @@
     <c:set var="dat" value="date"/>
     <c:set var="bot" value="both"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- the type attribute specifies the the type of date
              information is contained in the value to be parsed. -->

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.jsp
@@ -30,7 +30,7 @@
     <c:set var="dat" value="date"/>
     <c:set var="bot" value="both"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- the type attribute specifies the the type of date
              information is contained in the value to be parsed. -->

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDValueTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDValueTest.jsp
@@ -23,7 +23,7 @@
 <tck:test testName="positivePDValueTest">
     <c:set var="dte" value="Nov 21, 2000"/>
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="America/New_York"/>
 
     <!-- Validate the the action can properly parse a date
              provided as a dynamic or static value. -->

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneAttrScopeTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneAttrScopeTest.jsp
@@ -25,19 +25,19 @@
     <!-- If scope is specified and var is not, the
              jakarta.servlet.jsp.jstl.fmt.timeZone attribute will
              be set to the scope specified (implicit or explicit). -->
-    <fmt:setTimeZone value="PST"/>
+    <fmt:setTimeZone value="America/Los_Angeles"/>
     <tck:checkScope varName="jakarta.servlet.jsp.jstl.fmt.timeZone" useConfig="true"/>
     <c:remove var="jakarta.servlet.jsp.jstl.fmt.timeZone.page"/>
-    <fmt:setTimeZone value="PST" scope="page"/>
+    <fmt:setTimeZone value="America/Los_Angeles" scope="page"/>
     <tck:checkScope varName="jakarta.servlet.jsp.jstl.fmt.timeZone" useConfig="true"/>
     <c:remove var="jakarta.servlet.jsp.jstl.fmt.timeZone.page"/>
-    <fmt:setTimeZone value="PST" scope="request"/>
+    <fmt:setTimeZone value="America/Los_Angeles" scope="request"/>
     <tck:checkScope varName="jakarta.servlet.jsp.jstl.fmt.timeZone" inScope="request" useConfig="true"/>
     <c:remove var="jakarta.servlet.jsp.jstl.fmt.timeZone.request"/>
-    <fmt:setTimeZone value="PST" scope="session"/>
+    <fmt:setTimeZone value="America/Los_Angeles" scope="session"/>
     <tck:checkScope varName="jakarta.servlet.jsp.jstl.fmt.timeZone" inScope="session" useConfig="true"/>
     <c:remove var="jakarta.servlet.jsp.jstl.fmt.timeZone.session"/>
-    <fmt:setTimeZone value="PST" scope="application"/>
+    <fmt:setTimeZone value="America/Los_Angeles" scope="application"/>
     <tck:checkScope varName="jakarta.servlet.jsp.jstl.fmt.timeZone" inScope="application" useConfig="true"/>
     <c:remove var="jakarta.servlet.jsp.jstl.fmt.timeZone.applciation"/>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneScopeTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneScopeTest.jsp
@@ -24,11 +24,11 @@
     <!-- Validate that that var is exported to the appropriate
              scope as specified by the scope attribute explicitly
              or implicitly. -->
-    <fmt:setTimeZone value="PST" var="riPage"/>
-    <fmt:setTimeZone value="PST" var="rePage" scope="page"/>
-    <fmt:setTimeZone value="PST" var="reRequest" scope="request"/>
-    <fmt:setTimeZone value="PST" var="reSession" scope="session"/>
-    <fmt:setTimeZone value="PST" var="reApplication" scope="application"/>
+    <fmt:setTimeZone value="America/Los_Angeles" var="riPage"/>
+    <fmt:setTimeZone value="America/Los_Angeles" var="rePage" scope="page"/>
+    <fmt:setTimeZone value="America/Los_Angeles" var="reRequest" scope="request"/>
+    <fmt:setTimeZone value="America/Los_Angeles" var="reSession" scope="session"/>
+    <fmt:setTimeZone value="America/Los_Angeles" var="reApplication" scope="application"/>
     <tck:checkScope varName="riPage"/>
     <tck:checkScope varName="rePage"/>
     <tck:checkScope varName="reRequest" inScope="request"/>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneSetAttrTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneSetAttrTest.jsp
@@ -25,7 +25,7 @@
     <!-- timezone action with no var will set the
              jakarta.servlet.jsp.jstl.fmt.timeZone scoped
              attribute -->
-    <fmt:setTimeZone value="PST"/>
+    <fmt:setTimeZone value="America/Los_Angeles"/>
     <tck:config op="get" configVar="timezone" var="rtz"/>
     <tck:isInstance varName="rtz" type="java.util.TimeZone"/>
     <c:remove var="jakarta.servlet.jsp.jstl.fmt.timeZone.page"/>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTest.jsp
@@ -25,7 +25,7 @@
 <%@ page import="java.util.TimeZone,java.util.Date" %>
 <tck:test testName="positiveTimezoneValueTest">
    <%
-        TimeZone tz = TimeZone.getTimeZone("PST");
+        TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
         pageContext.setAttribute("tz", tz);
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneVarTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneVarTest.jsp
@@ -23,6 +23,6 @@
 
     <!-- Timezone can be exported for use by other actions.
              Type should be java.util.Timezone -->
-    <fmt:setTimeZone value="PST" var="rtz"/>
+    <fmt:setTimeZone value="America/Los_Angeles" var="rtz"/>
     <tck:isInstance varName="rtz" type="java.util.TimeZone"/>
 </tck:test>

--- a/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueTest.jsp
+++ b/tck/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueTest.jsp
@@ -25,12 +25,12 @@
 <%@ page import="java.util.TimeZone,java.util.Date" %>
 <tck:test testName="positiveTimezoneValueTest">
     <%
-        TimeZone tz = TimeZone.getTimeZone("PST");
+        TimeZone tz = TimeZone.getTimeZone("America/Los_Angeles");
         pageContext.setAttribute("tz", tz);
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
-    <c:set var="mtz" value="PST"/>
+    <c:set var="mtz" value="America/Los_Angeles"/>
 
     <!-- Behavioral test of value attribute -->
     <!-- Timezone object -->


### PR DESCRIPTION
This updates the Tags TCK tests to avoid legacy short timezone IDs as executable timezone inputs.

Changes:
- Replaced `EST`, `PST`, and `MST` inputs passed to JSTL timezone attributes and `TimeZone.getTimeZone(...)` with region IDs:
    - `America/New_York`
    - `America/Los_Angeles`
    - `America/Denver`
- Replaced parse-date input strings that embedded `EST` with `GMT-05:00`, preserving the same offset while avoiding the legacy short ID.
- Updated related explanatory test text and golden files where the output describes the timezone value being exercised.

Verification:

- `git diff --check` passed.
- Targeted source search found no remaining `EST`, `PST`, or `MST` usage in executable timezone inputs.
- Ran the patched `tags-tck` tests using WebLogic Server and JDK 25 to verify that all tests are passing and the deprecation warnings about the legacy timezone specifiers are no longer present.  `Tests run: 535, Failures: 0, Errors: 0, Skipped: 0`
