### PR TITLE
[maven-release-plugin] prepare release 3.1.0-M2-API-RELEASE

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -30,7 +30,7 @@
 
     <groupId>jakarta.servlet.jsp.jstl</groupId>
     <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0-M2</version>
     <packaging>jar</packaging>
 
     <name>Jakarta Standard Tag Library API</name>
@@ -77,7 +77,7 @@
         <connection>scm:git:https://github.com/jakartaee/tags.git</connection>
         <developerConnection>scm:git:ssh://github.com/jakartaee/tags.git</developerConnection>
         <url>https://github.com/jakartaee/tags</url>
-        <tag>HEAD</tag>
+        <tag>3.1.0-M2-API-RELEASE</tag>
     </scm>
     <issueManagement>
         <system>github</system>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.glassfish.web</groupId>
     <artifactId>jstl</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0-M2</version>
     <packaging>pom</packaging>
 
     <name>GlassFish Jakarta Standard Tag Library related modules</name>
@@ -68,7 +68,7 @@
         <connection>scm:git:https://github.com/eclipse-ee4j/jstl-api.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse-ee4j/jstl-api.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/jstl-api</url>
-        <tag>HEAD</tag>
+        <tag>3.1.0-M2-API-RELEASE</tag>
     </scm>
     <issueManagement>
         <system>github</system>
@@ -76,7 +76,7 @@
     </issueManagement>
 
     <properties>
-        <findbugs.exclude></findbugs.exclude>
+        <findbugs.exclude />
         <findbugs.version>3.0.5</findbugs.version>
     </properties>
 

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.stl</groupId>
     <artifactId>jakarta-stl-spec</artifactId>
-    <version>3.1.0-SNAPSHOT</version>
+    <version>3.1.0-M2</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Standard Tag Library Specification</name>
@@ -38,7 +38,7 @@
         <connection>scm:git:git@github.com:eclipse-ee4j/jakarta-stl-spec.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse-ee4j/jakarta-stl-spec.git</developerConnection>
         <url>https://github.com/eclipse-ee4j/jakarta-stl-spec</url>
-        <tag>HEAD</tag>
+        <tag>3.1.0-M2-API-RELEASE</tag>
     </scm>
     <distributionManagement>
         <site>

--- a/tagsdoc/pom.xml
+++ b/tagsdoc/pom.xml
@@ -15,12 +15,11 @@
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
 -->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.glassfish.web</groupId>
     <artifactId>tagsdoc</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>3.1.0-M2</version>
     <licenses>
         <license>
             <name>New BSD License</name>


### PR DESCRIPTION
3.1.0-M2 was released, but no branches were pushed by the jenkins job. Should I make a PR like this or try to create a jenkins job to push the commits / tags up? 

Need another commit to update poms for the next snapshot (3.1.0-M3-SNAPSHOT)